### PR TITLE
0.9.1 Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "breakpad-symbols"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "failure",
  "log",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "doc-comment",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-common"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-processor"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "addr2line 0.15.2",
  "breakpad-symbols",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-stackwalk"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "addr2line 0.15.2",
  "clap",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-tools"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "breakpad-symbols",
  "disasm",

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breakpad-symbols"
 description = "A library for working with Google Breakpad's text-format symbol files."
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 documentation = "https://docs.rs/breakpad-symbols"
@@ -14,7 +14,7 @@ edition = "2018"
 travis-ci = { repository = "luser/rust-minidump" }
 
 [dependencies]
-minidump-common = { version = "0.9.0", path = "../minidump-common" }
+minidump-common = { version = "0.9.1", path = "../minidump-common" }
 range-map = "0.1.5"
 nom = "~1.2.2"
 log = "0.4.1"

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump-common"
 description = "Some common types for working with minidump files."
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 readme = "README.md"
 license = "MIT"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump-processor"
 description = "A library and tool for producing stack traces and other useful information from minidump files."
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 readme = "README.md"
@@ -22,14 +22,14 @@ symbolic-syms = []
 
 [dependencies]
 addr2line = "0.15.2"
-breakpad-symbols = { version = "0.9.0", path = "../breakpad-symbols", optional = true }
+breakpad-symbols = { version = "0.9.1", path = "../breakpad-symbols", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 clap = "2.33"
 failure = "0.1.1"
 gimli = "0.24"
 log = "0.4"
 memmap = "0.7.0"
-minidump = { version = "0.9.0", path = "../minidump" }
+minidump = { version = "0.9.1", path = "../minidump" }
 object = "0.24"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump-stackwalk"
 description = "A CLI minidump analyzer"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 documentation = "https://docs.rs/minidump-stackwalk"
@@ -19,7 +19,7 @@ travis-ci = { repository = "luser/rust-minidump" }
 addr2line = "0.15.2"
 clap = "2.33"
 log = "0.4"
-minidump = { version = "0.9.0", path = "../minidump" }
-minidump-processor = { version = "0.9.0", path = "../minidump-processor" }
+minidump = { version = "0.9.1", path = "../minidump" }
+minidump-processor = { version = "0.9.1", path = "../minidump-processor" }
 simplelog = "0.10.2"
 

--- a/minidump-tools/Cargo.toml
+++ b/minidump-tools/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "minidump-tools"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 edition = "2018"
 
 [dependencies]
-breakpad-symbols = { version = "0.9.0", path = "../breakpad-symbols" }
+breakpad-symbols = { version = "0.9.1", path = "../breakpad-symbols" }
 failure = "0.1.1"
-minidump = { version = "0.9.0", path = "../minidump" }
-minidump-common = { version = "0.9.0", path = "../minidump-common" }
+minidump = { version = "0.9.1", path = "../minidump" }
+minidump-common = { version = "0.9.1", path = "../minidump-common" }
 structopt = { version = "0.3", default-features = false }
 disasm = { git = "https://github.com/luser/rust-disasm", rev = "274ff86cd5258e8e6534d93ad7a063105b7ecb99" }
 reqwest = { version = "0.10.8", features = ["blocking"] }

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minidump"
 description = "A parser for the minidump format."
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
 documentation = "https://luser.github.io/rust-project-docs/minidump/minidump/"
@@ -16,7 +16,7 @@ edition = "2018"
 failure = "0.1.1"
 range-map = "0.1.5"
 log = "0.4.1"
-minidump-common = { version = "0.9.0", path = "../minidump-common" }
+minidump-common = { version = "0.9.1", path = "../minidump-common" }
 num-traits = "0.2"
 encoding = "0.2"
 chrono = "0.4.6"


### PR DESCRIPTION
Iterating closer to parity with mozilla's minidump-stackwalk

Notable Changes (For both 0.9.0 and 0.9.1):

## minidump-stackwalk:

  * json schema
      * "exploitability" is now `null` instead of "TODO"
      * modules now have more debug stats:
          * "missing_symbols"
          * "loaded_symbols"
          * "corrupt_symbols"
          * "symbol_url"
      * modules now have "filename" actually be the filename and not full path
      * modules now have "cert_subject" indicating the module was code signed
      * new top level field "modules_contains_cert_info" (indicating whether
        we have any known-signed modules.)
  * cli
      * cli has just been massively cleaned up, now has much more documentation
      * --symbols-tmp is now implemented
          * Symbols that are downloaded are now downloaded to this location and
            atomically swapped into the cache, allowing multiple processes to
            share the cache safely.
      * --symbols-tmp and --symbols-cache now default to using std::env::temp_dir()
          to improve portability/ergonomics
      * new flags for writing output to specific files
          * --output-file
          * --log-file
      * --raw-json flag is now implemented
          * feeds into the certificate info in the json schema
          * please don't use this unless you're mozilla
              * if you are mozilla please stop using this too
      * logging should be a bit less noisy

## breakpad-symbols/minidump-processor

  * Symbolizers now have a `stats` method for getting stats on the symbols
      * See minidump-stackwalk's new "debug stats"
  * Symbolizing now has tweaked error types
      * Can now distinguish between
          * "had symbols but address had no entry" and "had no symbols"
          * this is used to refine stack scanning in the unwinder
      * Can now distinguish between "failed to load" and "failed to parse"
          * Surfaced in "corrupt_symbols" statistic
  * Symbolizer now truncates PUBLIC entries if there is a FUNC record in the way
      * Reduces the rate of false-positive symbolications
  * Unwinding quality has been massively improved
  * Unwinders now handle STACK WIN cfi
  * Unwinders now more intelligently select how hard they validate output frames
      * "better" techniques like CFI and Frame Pointers get less validation
      * This means we will happily unwind into a frame we don't have symbols for
        with CFI and Frame Pointers, which makes subsequent Scan and Frame Pointer
        unwinds more reliable (since they're starting from a more accurate position).
  * Unwinders now handle ARM64 pointer auth (high bits masked off)

## rust-minidump/minidump-common/minidump-tools
  * Should be largely unchanged. Any changes are incidental to refactors.

## misc fixes
  * removed some excessive logging
  * fixed some panics (an overflow and over-permissive parser)