### PR TITLE
[WIP] use newer version of test-assembler to get better errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
  "range-map",
  "scroll",
  "synth-minidump",
- "test-assembler",
+ "test-assembler 0.1.6",
  "thiserror",
  "time 0.3.7",
  "uuid",
@@ -697,7 +697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "synth-minidump",
- "test-assembler",
+ "test-assembler 0.1.7-alpha.0",
  "thiserror",
  "tokio",
 ]
@@ -715,7 +715,7 @@ dependencies = [
  "openssl",
  "simplelog",
  "synth-minidump",
- "test-assembler",
+ "test-assembler 0.1.6",
  "tokio",
 ]
 
@@ -1215,7 +1215,7 @@ dependencies = [
  "encoding",
  "minidump-common",
  "scroll",
- "test-assembler",
+ "test-assembler 0.1.7-alpha.0",
 ]
 
 [[package]]
@@ -1266,6 +1266,13 @@ name = "test-assembler"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a6da51de149453f5c43fa67d5e73cccd75b3c5727a38a2f18c5f3c47f2db582"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "test-assembler"
+version = "0.1.7-alpha.0"
 dependencies = [
  "byteorder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
  "range-map",
  "scroll",
  "synth-minidump",
- "test-assembler 0.1.6",
+ "test-assembler",
  "thiserror",
  "time 0.3.7",
  "uuid",
@@ -697,7 +697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "synth-minidump",
- "test-assembler 0.1.7-alpha.0",
+ "test-assembler",
  "thiserror",
  "tokio",
 ]
@@ -715,7 +715,7 @@ dependencies = [
  "openssl",
  "simplelog",
  "synth-minidump",
- "test-assembler 0.1.6",
+ "test-assembler",
  "tokio",
 ]
 
@@ -1215,7 +1215,7 @@ dependencies = [
  "encoding",
  "minidump-common",
  "scroll",
- "test-assembler 0.1.7-alpha.0",
+ "test-assembler",
 ]
 
 [[package]]
@@ -1259,15 +1259,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "test-assembler"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6da51de149453f5c43fa67d5e73cccd75b3c5727a38a2f18c5f3c47f2db582"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -33,6 +33,8 @@ serde_json = "1.0"
 thiserror = "1.0.30"
 
 [dev-dependencies]
+test-assembler = { path = "../../rust-test-assembler" }
+synth-minidump = { path = "../synth-minidump" }
 doc-comment = "0.3.3"
 synth-minidump = { path = "../synth-minidump" }
 test-assembler = "0.1.6"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -36,6 +36,4 @@ thiserror = "1.0.30"
 test-assembler = { path = "../../rust-test-assembler" }
 synth-minidump = { path = "../synth-minidump" }
 doc-comment = "0.3.3"
-synth-minidump = { path = "../synth-minidump" }
-test-assembler = "0.1.6"
 tokio =  { version = "1.12.0", features = ["full"] }

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -93,7 +93,7 @@ async fn test_caller_pushed_rbp() {
     let frame1_sp = Label::new();
     let frame1_rbp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D64(0x00007400b0000000) // junk that's not
@@ -167,7 +167,7 @@ async fn test_scan_without_symbols() {
     let frame1_sp = Label::new();
     let frame2_sp = Label::new();
     let frame1_rbp = Label::new();
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D64(0x00007400b0000000) // junk that's not
@@ -256,7 +256,7 @@ async fn test_scan_with_symbols() {
 
     let frame1_rsp = Label::new();
     let frame1_rbp = Label::new();
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D64(0x00007400b0000000u64) // junk that's not
@@ -419,7 +419,7 @@ async fn test_cfi_at_4000() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x00007400c0005510)
         .mark(&frame1_rsp)
         .append_repeated(0, 1000);
@@ -435,7 +435,7 @@ async fn test_cfi_at_4001() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x5a5beeb38de23be8) // saved %rbx
         .D64(0x00007400c0005510) // return address
         .mark(&frame1_rsp)
@@ -453,7 +453,7 @@ async fn test_cfi_at_4002() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x5a5beeb38de23be8) // saved %rbx
         .D64(0x00007400c0005510) // return address
         .mark(&frame1_rsp)
@@ -472,7 +472,7 @@ async fn test_cfi_at_4003() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x0e023828dffd4d81) // garbage
         .D64(0x1d20ad8acacbe930) // saved %r13
         .D64(0x319e68b49e3ace0f) // garbage
@@ -495,7 +495,7 @@ async fn test_cfi_at_4004() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x0e023828dffd4d81) // garbage
         .D64(0x1d20ad8acacbe930) // saved %r13
         .D64(0x319e68b49e3ace0f) // garbage
@@ -518,7 +518,7 @@ async fn test_cfi_at_4005() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x4b516dd035745953) // garbage
         .D64(0x1d20ad8acacbe930) // saved %r13
         .D64(0xa6d445e16ae3d872) // garbage
@@ -542,7 +542,7 @@ async fn test_cfi_at_4006() {
 
     let frame0_rbp = Label::new();
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D64(0x043c6dfceb91aa34) // garbage
         .D64(0x1d20ad8acacbe930) // saved %r13
         .D64(0x68995b1de4700266) // saved %rbp
@@ -577,7 +577,7 @@ async fn test_frame_pointer_overflow() {
     let stack_start: Pointer = stack_max - stack_size;
     stack.start().set_const(stack_start as u64);
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, stack_size as usize); // junk, not important to the test
 
@@ -614,7 +614,7 @@ async fn test_frame_pointer_barely_no_overflow() {
     let frame1_sp = Label::new();
     let frame1_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .mark(&frame0_fp)
         .D64(&frame1_fp) // caller-pushed %rbp

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -93,7 +93,7 @@ async fn test_scan_without_symbols() {
     let frame1_sp = Label::new();
     let frame2_sp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D64(0x40090000) // junk that's not
@@ -180,7 +180,7 @@ async fn test_scan_with_symbols() {
     let return_address = 0x50000200;
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D64(0x40090000) // junk that's not
@@ -251,7 +251,7 @@ async fn test_scan_first_frame() {
     let frame1_sp = Label::new();
     let frame2_sp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D64(0x40090000) // junk that's not
@@ -319,7 +319,7 @@ async fn test_frame_pointer() {
     let frame1_fp = Label::new();
     let frame2_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 64) // space
         .D64(0x0000000D) // junk that's not
@@ -429,7 +429,7 @@ async fn test_ptr_auth_strip() {
     let frame1_fp = Label::new();
     let frame2_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 64) // space
         .D64(0x0000000D) // junk that's not
@@ -639,7 +639,7 @@ async fn check_cfi(
 async fn test_cfi_at_4000() {
     let (mut f, mut stack, expected, expected_valid) = init_cfi_state();
 
-    stack = stack.append_repeated(0, 120);
+    stack.append_repeated(0, 120);
 
     f.raw.set_register("pc", 0x0000000040004000);
     f.raw.set_register("lr", 0x0000000040005510);
@@ -652,7 +652,7 @@ async fn test_cfi_at_4001() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D64(0x5e68b5d5b5d55e68) // saved x19
         .D64(0x34f3ebd1ebd134f3) // saved x20
         .D64(0xe11081128112e110) // saved fp
@@ -674,7 +674,7 @@ async fn test_cfi_at_4002() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D64(0xff3dfb81fb81ff3d) // no longer saved x19
         .D64(0x34f3ebd1ebd134f3) // no longer saved x20
         .D64(0xe11081128112e110) // saved fp
@@ -702,7 +702,7 @@ async fn test_cfi_at_4003() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
         .D64(0xff3dfb81fb81ff3d) // no longer saved x19
         .D64(0x34f3ebd1ebd134f3) // no longer saved x20
@@ -733,7 +733,7 @@ async fn test_cfi_at_4004() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
         .D64(0xff3dfb81fb81ff3d) // no longer saved x19
         .D64(0x34f3ebd1ebd134f3) // no longer saved x20
@@ -765,7 +765,7 @@ async fn test_cfi_at_4005() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
         .D64(0xff3dfb81fb81ff3d) // no longer saved x19
         .D64(0x34f3ebd1ebd134f3) // no longer saved x20
@@ -796,7 +796,7 @@ async fn test_cfi_at_4006() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D64(0x0000000040005510) // saved pc
         .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
         .D64(0xff3dfb81fb81ff3d) // no longer saved x19
@@ -827,7 +827,7 @@ async fn test_cfi_reject_backwards() {
 
     let (mut f, mut stack, _expected, _expected_valid) = init_cfi_state();
 
-    stack = stack.append_repeated(0, 120);
+    stack.append_repeated(0, 120);
 
     f.raw.set_register("pc", 0x0000000040006000);
     f.raw.set_register("sp", 0x0000000080000000);
@@ -843,7 +843,7 @@ async fn test_cfi_reject_bad_exprs() {
 
     let (mut f, mut stack, _expected, _expected_valid) = init_cfi_state();
 
-    stack = stack.append_repeated(0, 120);
+    stack.append_repeated(0, 120);
 
     f.raw.set_register("pc", 0x0000000040007000);
     f.raw.set_register("sp", 0x0000000080000000);
@@ -867,7 +867,7 @@ async fn test_frame_pointer_overflow() {
     let stack_start: Pointer = stack_max - stack_size;
     stack.start().set_const(stack_start as u64);
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, stack_size as usize); // junk, not important to the test
 
@@ -906,7 +906,7 @@ async fn test_frame_pointer_barely_no_overflow() {
     let frame1_sp = Label::new();
     let frame1_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .mark(&frame0_fp)
         .D64(&frame1_fp) // caller-pushed %rbp
@@ -997,7 +997,7 @@ async fn test_frame_pointer_infinite_equality() {
     let frame1_fp = Label::new();
     let frame2_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 64) // space
         .D64(0x0000000D) // junk that's not

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -89,7 +89,7 @@ async fn test_scan_without_symbols() {
     let frame1_sp = Label::new();
     let frame2_sp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D32(0x40090000) // junk that's not
@@ -176,7 +176,7 @@ async fn test_scan_first_frame() {
     let frame1_sp = Label::new();
     let frame2_sp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 16) // space
         .D32(0x40090000) // junk that's not
@@ -245,7 +245,7 @@ async fn test_frame_pointer() {
     let frame1_fp = Label::new();
     let frame2_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 32) // space
         .D32(0x0000000D) // junk that's not
@@ -359,7 +359,7 @@ async fn test_frame_pointer_infinite_equality() {
     let frame1_fp = Label::new();
     let frame2_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 32) // space
         .D32(0x0000000D) // junk that's not
@@ -541,7 +541,7 @@ async fn check_cfi(
 async fn test_cfi_at_4000() {
     let (mut f, mut stack, expected, expected_valid) = init_cfi_state();
 
-    stack = stack.append_repeated(0, 120);
+    stack.append_repeated(0, 120);
 
     f.raw.set_register("pc", 0x40004000);
     f.raw.set_register("lr", 0x40005510);
@@ -554,7 +554,7 @@ async fn test_cfi_at_4001() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D32(0xb5d55e68) // saved r4
         .D32(0x8112e110) // saved fp
         .D32(0x40005510) // return address
@@ -574,7 +574,7 @@ async fn test_cfi_at_4002() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D32(0xfb81ff3d) // no longer saved r4
         .D32(0x8112e110) // saved fp
         .D32(0x40005510) // return address
@@ -601,7 +601,7 @@ async fn test_cfi_at_4003() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D32(0x48c8dd5a) // saved r1 (even though it's not callee-saves)
         .D32(0xcb78040e) // no longer saved r4
         .D32(0x8112e110) // saved fp
@@ -629,7 +629,7 @@ async fn test_cfi_at_4004() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D32(0x48c8dd5a) // saved r1 (even though it's not callee-saves)
         .D32(0xcb78040e) // no longer saved r4
         .D32(0x8112e110) // saved fp
@@ -656,7 +656,7 @@ async fn test_cfi_at_4005() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D32(0x48c8dd5a) // saved r1 (even though it's not callee-saves)
         .D32(0xf013f841) // no longer saved r4
         .D32(0x8112e110) // saved fp
@@ -686,7 +686,7 @@ async fn test_cfi_at_4006() {
     let (mut f, mut stack, mut expected, mut expected_valid) = init_cfi_state();
 
     let frame1_sp = Label::new();
-    stack = stack
+    stack
         .D32(0x40005510) // saved pc
         .D32(0x48c8dd5a) // saved r1 (even though it's not callee-saves)
         .D32(0xf013f841) // no longer saved r4
@@ -716,7 +716,7 @@ async fn test_cfi_reject_backwards() {
 
     let (mut f, mut stack, _expected, _expected_valid) = init_cfi_state();
 
-    stack = stack.append_repeated(0, 120);
+    stack.append_repeated(0, 120);
 
     f.raw.set_register("pc", 0x40006000);
     f.raw.set_register("sp", 0x80000000);
@@ -732,7 +732,7 @@ async fn test_cfi_reject_bad_exprs() {
 
     let (mut f, mut stack, _expected, _expected_valid) = init_cfi_state();
 
-    stack = stack.append_repeated(0, 120);
+    stack.append_repeated(0, 120);
 
     f.raw.set_register("pc", 0x40007000);
     f.raw.set_register("sp", 0x80000000);
@@ -756,7 +756,7 @@ async fn test_frame_pointer_overflow() {
     let stack_start: Pointer = stack_max - stack_size;
     stack.start().set_const(stack_start as u64);
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, stack_size as usize); // junk, not important to the test
 
@@ -792,7 +792,7 @@ async fn test_frame_pointer_overflow_nonsense_32bit_stack() {
     let stack_start: u64 = stack_max - stack_size;
     stack.start().set_const(stack_start as u64);
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 1000); // junk, not important to the test
 
@@ -831,7 +831,7 @@ async fn test_frame_pointer_barely_no_overflow() {
     let frame1_sp = Label::new();
     let frame1_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .mark(&frame0_fp)
         .D32(&frame1_fp) // caller-pushed %rbp

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -63,7 +63,7 @@ async fn test_simple() {
     let mut f = TestFixture::new();
     let mut stack = Section::new();
     stack.start().set_const(0x80000000);
-    stack = stack.D32(0).D32(0); // end-of-stack marker
+    stack.D32(0).D32(0); // end-of-stack marker
     f.raw.eip = 0x40000200;
     f.raw.ebp = 0x80000000;
     let s = f.walk_stack(stack).await;
@@ -83,7 +83,7 @@ async fn test_traditional() {
     let frame1_ebp = Label::new();
     let mut stack = Section::new();
     stack.start().set_const(0x80000000);
-    stack = stack
+    stack
         .append_repeated(12, 0) // frame 0: space
         .mark(&frame0_ebp) // frame 0 %ebp points here
         .D32(&frame1_ebp) // frame 0: saved %ebp
@@ -125,7 +125,7 @@ async fn test_traditional_scan() {
     let mut stack = Section::new();
     let stack_start = 0x80000000;
     stack.start().set_const(stack_start);
-    stack = stack
+    stack
         // frame 0
         .D32(0xf065dc76) // locals area:
         .D32(0x46ee2167) // garbage that doesn't look like
@@ -197,7 +197,7 @@ async fn test_traditional_scan_long_way() {
     let stack_start = 0x80000000;
     stack.start().set_const(stack_start);
 
-    stack = stack
+    stack
         // frame 0
         .D32(0xf065dc76) // locals area:
         .D32(0x46ee2167) // garbage that doesn't look like
@@ -356,7 +356,7 @@ async fn test_cfi_at_4000() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0x40005510) // return address
         .mark(&frame1_rsp)
         .append_repeated(0, 1000);
@@ -372,7 +372,7 @@ async fn test_cfi_at_4001() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0x60f20ce6) // saved %ebx
         .D32(0x40005510) // return address
         .mark(&frame1_rsp)
@@ -390,7 +390,7 @@ async fn test_cfi_at_4002() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0x60f20ce6) // saved %ebx
         .D32(0x40005510) // return address
         .mark(&frame1_rsp)
@@ -409,7 +409,7 @@ async fn test_cfi_at_4003() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0x56ec3db7) // garbage
         .D32(0xafbae234) // saved %edi
         .D32(0x53d67131) // garbage
@@ -433,7 +433,7 @@ async fn test_cfi_at_4004() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0x56ec3db7) // garbage
         .D32(0xafbae234) // saved %edi
         .D32(0x53d67131) // garbage
@@ -456,7 +456,7 @@ async fn test_cfi_at_4005() {
     let (mut f, mut stack, mut expected, expected_valid) = init_cfi_state();
 
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0xe29782c2) // garbage
         .D32(0xafbae234) // saved %edi
         .D32(0x5ba29ce9) // garbage
@@ -480,7 +480,7 @@ async fn test_cfi_at_4006() {
 
     let frame0_ebp = Label::new();
     let frame1_rsp = Label::new();
-    stack = stack
+    stack
         .D32(0xdcdd25cd) // garbage
         .D32(0xafbae234) // saved %edi
         .D32(0xc0d4aab9) // saved %ebp
@@ -525,7 +525,7 @@ async fn test_stack_win_frame_data_basic() {
     let stack_start = 0x80000000;
     stack.start().set_const(stack_start);
 
-    stack = stack
+    stack
         // frame 0
         .D32(&frame1_ebp) // saved regs: %ebp
         .D32(0xa7120d1a) //             %esi
@@ -628,7 +628,7 @@ async fn test_stack_win_frame_data_overlapping() {
     let stack_start = 0x80000000;
     stack.start().set_const(stack_start);
 
-    stack = stack
+    stack
         // frame 0
         .D32(&frame1_ebp) // saved regs: %ebp
         .D32(0xa7120d1a) //             %esi
@@ -726,7 +726,7 @@ async fn test_stack_win_frame_data_parameter_size() {
     let stack_start = 0x80000000;
     stack.start().set_const(stack_start);
 
-    stack = stack
+    stack
         // frame 0, in module1::wheedle.  Traditional frame.
         .mark(&frame0_esp)
         .append_repeated(0, 16) // frame space
@@ -835,7 +835,7 @@ async fn test_frame_pointer_overflow() {
     let stack_start: Pointer = stack_max - stack_size;
     stack.start().set_const(stack_start as u64);
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, stack_size as usize); // junk, not important to the test
 
@@ -869,7 +869,7 @@ async fn test_frame_pointer_overflow_nonsense_32bit_stack() {
     let stack_start: u64 = stack_max - stack_size;
     stack.start().set_const(stack_start as u64);
 
-    stack = stack
+    stack
         // frame 0
         .append_repeated(0, 1000); // junk, not important to the test
 
@@ -906,7 +906,7 @@ async fn test_frame_pointer_barely_no_overflow() {
     let frame1_sp = Label::new();
     let frame1_fp = Label::new();
 
-    stack = stack
+    stack
         // frame 0
         .mark(&frame0_fp)
         .D32(&frame1_fp) // caller-pushed %rbp

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -33,4 +33,4 @@ optional = true
 [dev-dependencies]
 insta = "1.10.0"
 synth-minidump = { version = "0.9.6", path = "../synth-minidump" }
-test-assembler = "0.1.6"
+test-assembler = { path = "../../rust-test-assembler" }

--- a/minidump-stackwalk/tests/test-minidump-stackwalk.rs
+++ b/minidump-stackwalk/tests/test-minidump-stackwalk.rs
@@ -536,10 +536,9 @@ fn test_brief_robots() {
 
 fn minimal_minidump() -> SynthMinidump {
     let context = synth_minidump::x86_context(Endian::Little, 0xf00800, 0x1010);
-    let stack = Memory::with_section(
-        Section::with_endian(Endian::Little).append_repeated(0, 0x1000),
-        0x1000,
-    );
+    let mut section = Section::with_endian(Endian::Little);
+    section.append_repeated(0, 0x1000);
+    let stack = Memory::with_section(section, 0x1000);
     let thread = Thread::new(Endian::Little, 0x1234, &stack, &context);
     let system_info = SystemInfo::new(Endian::Little);
     SynthMinidump::with_endian(Endian::Little)

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -27,7 +27,7 @@ uuid = "0.8"
 
 [dev-dependencies]
 synth-minidump = { path = "../synth-minidump" }
-test-assembler = "0.1.6"
+test-assembler = { path = "../../rust-test-assembler" }
 doc-comment = "0.3.3"
 
 [features]

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -5877,8 +5877,8 @@ c70206ca83eb2852-de0206ca83eb2852  -w-s  10bac9000 fd:05 1196511 /usr/lib64/libt
     #[test]
     fn test_macos_ids() {
         let name = DumpString::new("macos module", Endian::Little);
-        let cv_record = Section::with_endian(Endian::Little)
-            // signature
+        let mut cv_record = Section::with_endian(Endian::Little);
+        cv_record // signature
             .D32(md::CvSignature::Pdb70 as u32)
             // signature, a GUID
             .D32(0xaabbccdd)
@@ -5962,11 +5962,8 @@ c70206ca83eb2852-de0206ca83eb2852  -w-s  10bac9000 fd:05 1196511 /usr/lib64/libt
         let context =
             synth_minidump::amd64_context(Endian::Little, 0x1234abcd1234abcd, 0x1000000010000000);
         let mut section = Section::with_endian(Endian::Little);
-            section.append_repeated(0, 0x1000);
-        let stack = Memory::with_section(
-        section,
-            0x1000000010000000,
-        );
+        section.append_repeated(0, 0x1000);
+        let stack = Memory::with_section(section, 0x1000000010000000);
         let arch = md::ProcessorArchitecture::PROCESSOR_ARCHITECTURE_AMD64 as u16;
         let system_info = SystemInfo::new(Endian::Little).set_processor_architecture(arch);
         let thread = Thread::new(Endian::Little, 0x1234, &stack, &context);

--- a/synth-minidump/Cargo.toml
+++ b/synth-minidump/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-test-assembler = "0.1.5"
+test-assembler = { path = "../../rust-test-assembler" }
 minidump-common = { version = "0.9.6", path = "../minidump-common" }
 encoding = "0.2"
 scroll = "0.10.2"

--- a/synth-minidump/src/lib.rs
+++ b/synth-minidump/src/lib.rs
@@ -449,7 +449,7 @@ impl SynthMinidump {
             stream_directory,
             ..
         } = self;
-        if flags.value().is_ok() {
+        if flags.value().is_err() {
             flags.set_const(0);
         }
         // Create the stream directory.


### PR DESCRIPTION
This won't work in CI since I used relative paths (I guess I could have used a git dependency for the crate, but :shrug:)

The diff is.... smaller than I was expecting.