### PR TITLE
feat: Add rudimentary MIPS support

### DIFF
--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -926,10 +926,10 @@ Unknown streams encountered:
     // Convert an integer to a hex string, with leading 0's for uniform width.
     fn json_hex(&self, val: u64) -> String {
         match self.system_info.cpu {
-            Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm => {
+            Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm | Cpu::Mips => {
                 format!("0x{:08x}", val)
             }
-            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 | Cpu::Unknown(_) => {
+            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 | Cpu::Mips64 | Cpu::Unknown(_) => {
                 format!("0x{:016x}", val)
             }
         }

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -929,7 +929,7 @@ Unknown streams encountered:
             Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm | Cpu::Mips => {
                 format!("0x{:08x}", val)
             }
-            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 | Cpu::Mips64 | Cpu::Unknown(_) => {
+            _ => {
                 format!("0x{:016x}", val)
             }
         }

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__dump.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__dump.snap
@@ -2,7 +2,6 @@
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
 assertion_line: 55
 expression: stdout
-
 ---
 MDRawHeader
   signature            = 0x504d444d
@@ -681,7 +680,7 @@ MINIDUMP_SYSTEM_INFO
   platform_id                                = 0x2
   csd_version_rva                            = 0x768
   suite_mask                                 = 0x100
-  (version)                                  = 512600 Service Pack 2
+  (version)                                  = 5.1.2600 Service Pack 2
   (cpu_info)                                 = GenuineIntel family 6 model 13 stepping 8
 
 MINIDUMP_MISC_INFO

--- a/minidump/src/system_info.rs
+++ b/minidump/src/system_info.rs
@@ -93,6 +93,8 @@ pub enum Cpu {
     Sparc,
     Arm,
     Arm64,
+    Mips,
+    Mips64,
     Unknown(u16),
 }
 
@@ -111,6 +113,8 @@ impl Cpu {
             Some(PROCESSOR_ARCHITECTURE_ARM64) | Some(PROCESSOR_ARCHITECTURE_ARM64_OLD) => {
                 Cpu::Arm64
             }
+            Some(PROCESSOR_ARCHITECTURE_MIPS) => Cpu::Mips,
+            Some(PROCESSOR_ARCHITECTURE_MIPS64) => Cpu::Mips64,
             _ => Cpu::Unknown(arch),
         }
     }
@@ -118,8 +122,8 @@ impl Cpu {
     /// The native pointer width of this platform
     pub fn pointer_width(&self) -> Option<u64> {
         match self {
-            Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm => Some(4),
-            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 => Some(8),
+            Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm | Cpu::Mips => Some(4),
+            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 | Cpu::Mips64 => Some(8),
             Cpu::Unknown(_) => None,
         }
     }
@@ -138,6 +142,8 @@ impl fmt::Display for Cpu {
                 Cpu::Sparc => "sparc",
                 Cpu::Arm => "arm",
                 Cpu::Arm64 => "arm64",
+                Cpu::Mips => "mips",
+                Cpu::Mips64 => "mips64",
                 Cpu::Unknown(_) => "unknown",
             }
         )

--- a/minidump/src/system_info.rs
+++ b/minidump/src/system_info.rs
@@ -85,6 +85,7 @@ impl fmt::Display for Os {
 /// This is a slightly nicer layer over the `ProcessorArchitecture` enum defined in
 /// the minidump-common crate.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Cpu {
     X86,
     X86_64,


### PR DESCRIPTION
In particular, this adds support for reading the CPU type and fixes some issues related to big-endian, such as UTF16 parsing, and DebugId parsing.

The Module DebugId parsing is now done at parsing-time because it needs to be endian aware.

For sentry folks, this fixes:
* Unknown minidump arch 1: https://sentry.my.sentry.io/organizations/sentry/issues/297362
* Garbage module names for example: https://sentry.my.sentry.io/organizations/sentry/issues/297548/events/99e6508a508744dd8aa19a06c57e5d23/

I’m a bit unsure how to write a unit-test for all this with reasonable effort 🤷🏻‍♂️