### PR TITLE
fixup cli from clap update

### DIFF
--- a/minidump-stackwalk/README.md
+++ b/minidump-stackwalk/README.md
@@ -176,11 +176,11 @@ minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...
 ### `<minidump>`
 Path to the minidump file to analyze.
 
-### `<symbols-path>...`
-Path to a symbol file.
+### `<symbols-path-legacy>...`
+Path to a symbol file. (Passed positionally)
 
-If multiple symbols-path values are provided, all symbol files will be merged into
-minidump-stackwalk's symbol database.
+If multiple symbols-path-legacy values are provided, all symbol files will be merged
+into minidump-stackwalk's symbol database.
 
 # OPTIONS
 ### `--json`
@@ -320,6 +320,12 @@ The maximum amount of time (in seconds) a symbol file download is allowed to tak
 This is necessary to enforce forward progress on misbehaving http responses.
 
 \[default: 1000]
+
+### `--symbols-path <symbols-path>`
+Path to a symbol file.
+
+If multiple symbols-path values are provided, all symbol files will be merged into
+minidump-stackwalk's symbol database.
 
 ### `-h, --help`
 Print help information

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -174,9 +174,8 @@ This is an experimental feature, which currently only shows up in --human output
         .arg(
             Arg::new("symbols-url")
                 .long("symbols-url")
-                .multiple_values(true)
+                .multiple_occurrences(true)
                 .takes_value(true)
-                .number_of_values(1)
                 .long_help(
                     "base URL from which URLs to symbol files can be constructed.
 
@@ -249,13 +248,26 @@ This is necessary to enforce forward progress on misbehaving http responses.",
         )
         .arg(
             Arg::new("symbols-path")
-                .multiple_values(true)
+                .long("symbols-path")
+                .multiple_occurrences(true)
                 .takes_value(true)
                 .allow_invalid_utf8(true)
                 .long_help(
                     "Path to a symbol file.
 
 If multiple symbols-path values are provided, all symbol files will be merged \
+into minidump-stackwalk's symbol database.",
+                ),
+        )
+        .arg(
+            Arg::new("symbols-path-legacy")
+                .multiple_values(true)
+                .takes_value(true)
+                .allow_invalid_utf8(true)
+                .long_help(
+                    "Path to a symbol file. (Passed positionally)
+
+If multiple symbols-path-legacy values are provided, all symbol files will be merged \
 into minidump-stackwalk's symbol database.",
                 ),
         )
@@ -389,13 +401,21 @@ async fn main() {
 
     let temp_dir = std::env::temp_dir();
 
-    let symbols_paths = matches
+    let mut symbols_paths = matches
         .values_of_os("symbols-path")
         .map(|v| {
             v.map(|os_str| Path::new(os_str).to_owned())
                 .collect::<Vec<_>>()
         })
         .unwrap_or_else(Vec::new);
+    let symbols_paths_legacy = matches
+        .values_of_os("symbols-path-legacy")
+        .map(|v| {
+            v.map(|os_str| Path::new(os_str).to_owned())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(Vec::new);
+    symbols_paths.extend(symbols_paths_legacy);
 
     // Default to env::temp_dir()/rust-minidump-cache
     let symbols_cache = matches

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
@@ -13,11 +13,11 @@ ARGS:
     <minidump>
             Path to the minidump file to analyze.
 
-    <symbols-path>...
-            Path to a symbol file.
+    <symbols-path-legacy>...
+            Path to a symbol file. (Passed positionally)
             
-            If multiple symbols-path values are provided, all symbol files will be merged into
-            minidump-stackwalk's symbol database.
+            If multiple symbols-path-legacy values are provided, all symbol files will be merged
+            into minidump-stackwalk's symbol database.
 
 OPTIONS:
         --json
@@ -157,6 +157,12 @@ OPTIONS:
             This is necessary to enforce forward progress on misbehaving http responses.
             
             [default: 1000]
+
+        --symbols-path <symbols-path>
+            Path to a symbol file.
+            
+            If multiple symbols-path values are provided, all symbol files will be merged into
+            minidump-stackwalk's symbol database.
 
     -h, --help
             Print help information

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
@@ -18,11 +18,11 @@ minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...
 ### `<minidump>`
 Path to the minidump file to analyze.
 
-### `<symbols-path>...`
-Path to a symbol file.
+### `<symbols-path-legacy>...`
+Path to a symbol file. (Passed positionally)
 
-If multiple symbols-path values are provided, all symbol files will be merged into
-minidump-stackwalk's symbol database.
+If multiple symbols-path-legacy values are provided, all symbol files will be merged
+into minidump-stackwalk's symbol database.
 
 # OPTIONS
 ### `--json`
@@ -162,6 +162,12 @@ The maximum amount of time (in seconds) a symbol file download is allowed to tak
 This is necessary to enforce forward progress on misbehaving http responses.
 
 \[default: 1000]
+
+### `--symbols-path <symbols-path>`
+Path to a symbol file.
+
+If multiple symbols-path values are provided, all symbol files will be merged into
+minidump-stackwalk's symbol database.
 
 ### `-h, --help`
 Print help information

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
@@ -13,11 +13,11 @@ ARGS:
     <minidump>
             Path to the minidump file to analyze.
 
-    <symbols-path>...
-            Path to a symbol file.
+    <symbols-path-legacy>...
+            Path to a symbol file. (Passed positionally)
             
-            If multiple symbols-path values are provided, all symbol files will be merged into
-            minidump-stackwalk's symbol database.
+            If multiple symbols-path-legacy values are provided, all symbol files will be merged
+            into minidump-stackwalk's symbol database.
 
 OPTIONS:
         --json
@@ -156,6 +156,12 @@ OPTIONS:
             
             This is necessary to enforce forward progress on misbehaving http responses. [default:
             1000]
+
+        --symbols-path <symbols-path>
+            Path to a symbol file.
+            
+            If multiple symbols-path values are provided, all symbol files will be merged into
+            minidump-stackwalk's symbol database.
 
     -h, --help
             Print help information


### PR DESCRIPTION
* new way to specify an option can be passed repeatedly with only one value each
* use the new stuff to properly expose --symbols-path as a flag as well