### PR TITLE
Make the parser much more robust to enormous symbols.

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -3510,7 +3510,8 @@ impl MinidumpMiscInfo {
                 writeln!(f)?;
                 for (i, feature) in xstate_data.iter() {
                     if let Some(feature) = md::XstateFeatureIndex::from_index(i) {
-                        write!(f, "    feature {:2} - {:22}: ", i, format!("{:?}", feature))?;
+                        let feature_name = format!("{:?}", feature);
+                        write!(f, "    feature {:2} - {:22}: ", i, feature_name)?;
                     } else {
                         write!(f, "    feature {:2} - (unknown)           : ", i)?;
                     }


### PR DESCRIPTION
This teaches the parser to resize its buffer up to a reasonably maximum limit, and then if a line
slams into that maximum, it just enters a PANIC RECOVERY mode where it discards bytes until it
finds a newline or EOF, then resumes normal behaviour. This basically just ends up discarding horrible
enormous (80kb+) symbols instead of discarding the entire file.

Also this adds a bunch of "symbol:" TRACE logs to make figuring this stuff out easier in the future. In particular if we *do* end up discarding a bunch of your lines, that will be noted in the TRACE at least.