### PR TITLE
fix: Use the correct stack memory for exception context

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -1668,14 +1668,11 @@ impl<'a, Descriptor> MinidumpMemoryBase<'a, Descriptor> {
         T: TryFromCtx<'a, scroll::Endian, [u8], Error = scroll::Error>,
         T: SizeWith<scroll::Endian>,
     {
-        let end = self.base_address.checked_add(self.size)?;
+        // XXX: Instead of checking the base+size validity on each access, maybe
+        // move this check to a different place?
+        let _end = self.base_address.checked_add(self.size)?;
+        let start = addr.checked_sub(self.base_address)? as usize;
 
-        let in_range = |a: u64| a >= self.base_address && a < end;
-        let size = <T>::size_with(&LE);
-        if !in_range(addr) || !in_range(addr + size as u64 - 1) {
-            return None;
-        }
-        let start = (addr - self.base_address) as usize;
         self.bytes.pread_with::<T>(start, LE).ok()
     }
 


### PR DESCRIPTION
When a minidump has an exception context that is different from the thread context,
it may refer to a different memory region, which we should use in that case rather
than the stack memory region.

This also removes the confusing/duplicated bounds checking on memory access, as scroll does its own bounds checking when reading the value anyways.

This snippet here in breakpad does the same:

https://github.com/getsentry/breakpad/blob/63c90f00bf64a1b4a8883e50bbe8217048ed2a85/src/processor/stackwalker.cc#L201-L216

For Sentry folks: This should fix the problems where we can’t unwind past the context frame on the crashing thread: https://getsentry.atlassian.net/browse/ISSUE-1424