### PR TITLE
Use only the file name when sending the code file to a symbol server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "log",
  "memmap2",
  "minidump",
+ "minidump-common",
  "minidump-synth",
  "scroll",
  "serde",

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -52,7 +52,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 
-pub use minidump_common::traits::Module;
+pub use minidump_common::{traits::Module, utils::basename};
 pub use sym_file::walker;
 
 pub use crate::sym_file::{CfiRules, SymbolFile};
@@ -477,8 +477,8 @@ async fn fetch_symbol_file(
         .map_err(|_| SymbolError::NotFound)?;
     let code_id = module.code_identifier().unwrap_or_default();
     url.query_pairs_mut()
-        .append_pair("code_id", code_id.as_str())
-        .append_pair("code_file", &module.code_file());
+        .append_pair("code_file", basename(&module.code_file()))
+        .append_pair("code_id", code_id.as_str());
     debug!("Trying {}", url);
     let res = client
         .get(url.clone())

--- a/minidump-common/src/lib.rs
+++ b/minidump-common/src/lib.rs
@@ -11,3 +11,4 @@
 pub mod errors;
 pub mod format;
 pub mod traits;
+pub mod utils;

--- a/minidump-common/src/utils.rs
+++ b/minidump-common/src/utils.rs
@@ -1,0 +1,8 @@
+//! Utility functions, only pathname handling at the moment.
+
+pub fn basename(f: &str) -> &str {
+    match f.rfind(|c| c == '/' || c == '\\') {
+        None => f,
+        Some(index) => &f[(index + 1)..],
+    }
+}

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -26,6 +26,7 @@ debugid = "0.7.3"
 log = "0.4"
 memmap2 = "0.5.3"
 minidump = { version = "0.10.3", path = "../minidump" }
+minidump-common = { version = "0.10.3", path = "../minidump-common" }
 scroll = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -13,6 +13,7 @@ use crate::system_info::SystemInfo;
 use crate::{FrameSymbolizer, SymbolStats};
 use minidump::system_info::Cpu;
 use minidump::*;
+use minidump_common::utils::basename;
 use serde_json::json;
 
 /// Indicates how well the instruction pointer derived during
@@ -323,13 +324,6 @@ impl FrameSymbolizer for StackFrame {
         self.source_file_name = Some(String::from(file));
         self.source_line = Some(line);
         self.source_line_base = Some(base);
-    }
-}
-
-fn basename(f: &str) -> &str {
-    match f.rfind(|c| c == '/' || c == '\\') {
-        None => f,
-        Some(index) => &f[(index + 1)..],
     }
 }
 


### PR DESCRIPTION
This fixes issue #545