### PR TITLE
Gardening: migrate to clap-derive and tracing (with spans)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
  "lazy_static",
@@ -138,6 +139,19 @@ dependencies = [
  "termcolor",
  "terminal_size",
  "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -387,6 +401,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -796,6 +816,30 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1359,6 +1403,12 @@ name = "uuid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,7 +86,6 @@ dependencies = [
  "async-trait",
  "circular",
  "debugid",
- "log",
  "minidump-common",
  "nom",
  "range-map",
@@ -85,6 +93,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -625,7 +634,6 @@ dependencies = [
  "debugid",
  "doc-comment",
  "encoding",
- "log",
  "memmap2",
  "minidump-common",
  "minidump-synth",
@@ -635,6 +643,7 @@ dependencies = [
  "test-assembler",
  "thiserror",
  "time",
+ "tracing",
  "uuid",
 ]
 
@@ -646,11 +655,11 @@ dependencies = [
  "bitflags",
  "debugid",
  "enum-primitive-derive",
- "log",
  "num-traits 0.2.15",
  "range-map",
  "scroll",
  "smart-default",
+ "tracing",
 ]
 
 [[package]]
@@ -661,7 +670,6 @@ dependencies = [
  "breakpad-symbols",
  "debugid",
  "doc-comment",
- "log",
  "memmap2",
  "minidump",
  "minidump-common",
@@ -672,6 +680,7 @@ dependencies = [
  "test-assembler",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -680,14 +689,14 @@ version = "0.11.0"
 dependencies = [
  "clap",
  "insta",
- "log",
  "minidump",
  "minidump-common",
  "minidump-processor",
  "minidump-synth",
- "simplelog",
  "test-assembler",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1060,6 +1069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,17 +1091,6 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
-
-[[package]]
-name = "simplelog"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
 
 [[package]]
 name = "slab"
@@ -1213,6 +1220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,14 +1237,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "time-macros",
 ]
-
-[[package]]
-name = "time-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -1328,6 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1351,6 +1361,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1403,6 +1439,12 @@ name = "uuid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -23,7 +23,7 @@ http = ["reqwest", "tempfile"]
 async-trait = "0.1.51"
 circular = "0.3.0"
 debugid = "0.8.0"
-log = "0.4.1"
+tracing = { version = "0.1.34", features = ["log"] }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
 nom = "~1.2.2"
 range-map = "0.1.5"

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -602,10 +602,10 @@ impl Symbolizer {
         let k = key(module);
         self.ensure_module(module, &k).await;
         if let Some(Ok(ref sym)) = self.symbols.lock().unwrap().get(&k) {
-            trace!("unwind: found symbols for address, searching for cfi entries");
+            trace!("found symbols for address, searching for cfi entries");
             sym.walk_frame(module, walker)
         } else {
-            trace!("unwind: couldn't find symbols for address, cannot use cfi");
+            trace!("couldn't find symbols for address, cannot use cfi");
             None
         }
     }

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -235,17 +235,17 @@ pub enum SymbolError {
 #[derive(Debug)]
 pub struct FillSymbolError {
     // We don't want to yield a full SymbolError for fill_symbol
-// as this would involve cloning bulky Error strings every time
-// someone requested symbols for a missing module.
-//
-// As it turns out there's currently no reason to care about *why*
-// fill_symbol, so for now this is just a dummy type until we have
-// something to put here.
-//
-// The only reason fill_symbol *can* produce an Err is so that
-// the caller can distinguish between "we had symbols, but this address
-// didn't map to a function name" and "we had no symbols for that module"
-// (this is used as a heuristic for stack scanning).
+    // as this would involve cloning bulky Error strings every time
+    // someone requested symbols for a missing module.
+    //
+    // As it turns out there's currently no reason to care about *why*
+    // fill_symbol, so for now this is just a dummy type until we have
+    // something to put here.
+    //
+    // The only reason fill_symbol *can* produce an Err is so that
+    // the caller can distinguish between "we had symbols, but this address
+    // didn't map to a function name" and "we had no symbols for that module"
+    // (this is used as a heuristic for stack scanning).
 }
 
 impl PartialEq for SymbolError {

--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -3,11 +3,11 @@
 use crate::{FrameSymbolizer, FrameWalker, Module, SymbolError};
 
 pub use crate::sym_file::types::*;
-use log::trace;
 pub use parser::SymbolParser;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use tracing::trace;
 
 mod parser;
 mod types;
@@ -106,7 +106,7 @@ impl SymbolFile {
                     fully_consumed = false;
                     just_finished_recovering = true;
                     parser.lines += 1;
-                    trace!("symbols: RECOVERY: complete!");
+                    trace!("RECOVERY: complete!");
                 } else {
                     // No newline, discard everything
                     let amount = input.len();
@@ -142,17 +142,11 @@ impl SymbolFile {
                     if new_cap > MAX_BUFFER_CAPACITY {
                         // TIME TO PANIC!!! This line is catastrophically big, just start
                         // discarding bytes until we hit a newline.
-                        trace!(
-                            "symbols: RECOVERY: discarding enormous line {}",
-                            parser.lines
-                        );
+                        trace!("RECOVERY: discarding enormous line {}", parser.lines);
                         in_panic_recovery = true;
                         continue;
                     }
-                    trace!(
-                        "symbols: parser out of space? trying more ({}KB)",
-                        new_cap / 1024
-                    );
+                    trace!("parser out of space? trying more ({}KB)", new_cap / 1024);
                     buf.grow(new_cap);
                     tried_to_grow = true;
                     continue;
@@ -228,7 +222,7 @@ impl SymbolFile {
                     fully_consumed = false;
                     just_finished_recovering = true;
                     parser.lines += 1;
-                    trace!("symbols: PANIC RECOVERY: complete!");
+                    trace!("PANIC RECOVERY: complete!");
                 } else {
                     // No newline, discard everything
                     let amount = input.len();
@@ -280,17 +274,11 @@ impl SymbolFile {
                     if new_cap > MAX_BUFFER_CAPACITY {
                         // TIME TO PANIC!!! This line is catastrophically big, just start
                         // discarding bytes until we hit a newline.
-                        trace!(
-                            "symbols: RECOVERY: discarding enormous line {}",
-                            parser.lines
-                        );
+                        trace!("RECOVERY: discarding enormous line {}", parser.lines);
                         in_panic_recovery = true;
                         continue;
                     }
-                    trace!(
-                        "symbols: parser out of space? trying more ({}KB)",
-                        new_cap / 1024
-                    );
+                    trace!("parser out of space? trying more ({}KB)", new_cap / 1024);
                     buf.grow(new_cap);
                     tried_to_grow = true;
                     continue;

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -1,10 +1,10 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use log::warn;
 use nom::IResult::*;
 use nom::*;
 use range_map::{Range, RangeMap};
+use tracing::warn;
 
 use std::collections::HashMap;
 use std::fmt::Debug;

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -17,7 +17,7 @@ arbitrary = { version = "1", optional = true, features = ["derive"] }
 bitflags = "1.3.2"
 debugid = "0.8.0"
 enum-primitive-derive = "0.2.2"
-log = "0.4.1"
+tracing = { version = "0.1.34", features = ["log"] }
 num-traits = "0.2"
 range-map = "0.1.5"
 scroll = { version = "0.11.0", features = ["derive"] }

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -25,7 +25,7 @@ http = ["breakpad-symbols/http"]
 async-trait = "0.1.51"
 breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols", optional = true }
 debugid = "0.8.0"
-log = "0.4"
+tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.3"
 minidump = { version = "0.11.0", path = "../minidump" }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }

--- a/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
+++ b/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
@@ -58,6 +58,8 @@ impl TestFixture {
 
         Some(
             walk_stack(
+                0,
+                None,
                 &Some(&context),
                 Some(&stack_memory),
                 &self.modules,

--- a/minidump-processor/src/evil.rs
+++ b/minidump-processor/src/evil.rs
@@ -1,4 +1,3 @@
-use log::error;
 use serde_json::map::Map;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -6,6 +5,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use std::str::FromStr;
+use tracing::error;
 
 /// Things extracted from the Evil JSON File
 #[derive(Debug, Default)]

--- a/minidump-processor/src/stackwalker/amd64.rs
+++ b/minidump-processor/src/stackwalker/amd64.rs
@@ -10,7 +10,6 @@ use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
 use crate::{SymbolProvider, SystemInfo};
-use log::trace;
 use minidump::format::CONTEXT_AMD64;
 use minidump::system_info::Os;
 use minidump::{
@@ -18,6 +17,7 @@ use minidump::{
     MinidumpRawContext,
 };
 use std::collections::HashSet;
+use tracing::trace;
 
 type Pointer = u64;
 const POINTER_WIDTH: Pointer = 8;
@@ -38,7 +38,7 @@ async fn get_caller_by_cfi<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying cfi");
+    trace!("trying cfi");
 
     let valid = &callee.context.valid;
     if let MinidumpContextValidity::Some(ref which) = valid {
@@ -76,7 +76,7 @@ where
     let caller_sp = stack_walker.caller_ctx.rsp;
 
     trace!(
-        "unwind: cfi evaluation was successful -- caller_ip: 0x{:016x}, caller_sp: 0x{:016x}",
+        "cfi evaluation was successful -- caller_ip: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_ip,
         caller_sp,
     );
@@ -86,7 +86,7 @@ where
     // values are correct. I Don't Like This, but it's what breakpad does and
     // we should start with a baseline of parity.
 
-    trace!("unwind: cfi result seems valid");
+    trace!("cfi result seems valid");
 
     let context = MinidumpContext {
         raw: MinidumpRawContext::Amd64(stack_walker.caller_ctx),
@@ -129,7 +129,7 @@ where
         return None;
     }
 
-    trace!("unwind: trying frame pointer");
+    trace!("trying frame pointer");
     if let MinidumpContextValidity::Some(ref which) = callee.context.valid {
         if !which.contains(FRAME_POINTER_REGISTER) {
             return None;
@@ -180,7 +180,7 @@ where
     // Since we're assuming coherent frame pointers, check that the frame pointers
     // and stack pointers are well-ordered.
     if caller_sp <= last_bp || caller_bp < caller_sp {
-        trace!("unwind: rejecting frame pointer result for unreasonable frame pointer");
+        trace!("rejecting frame pointer result for unreasonable frame pointer");
         return None;
     }
     // Since we're assuming coherent frame pointers, check that the resulting
@@ -188,17 +188,17 @@ where
     let _unused: Pointer = stack_memory.get_memory_at_address(caller_bp as u64)?;
     // Don't accept obviously wrong instruction pointers.
     if is_non_canonical(caller_ip) {
-        trace!("unwind: rejecting frame pointer result for unreasonable instruction pointer");
+        trace!("rejecting frame pointer result for unreasonable instruction pointer");
         return None;
     }
     // Don't accept obviously wrong stack pointers.
     if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
-        trace!("unwind: rejecting frame pointer result for unreasonable stack pointer");
+        trace!("rejecting frame pointer result for unreasonable stack pointer");
         return None;
     }
 
     trace!(
-        "unwind: frame pointer seems valid -- caller_ip: 0x{:016x}, caller_sp: 0x{:016x}",
+        "frame pointer seems valid -- caller_ip: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_ip,
         caller_sp,
     );
@@ -230,7 +230,7 @@ async fn get_caller_by_scan<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying scan");
+    trace!("trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
     // a value on the stack that looks like a pointer into some code (it's an address
     // in a range covered by one of our modules). If we find such an instruction,
@@ -241,7 +241,7 @@ where
         MinidumpContextValidity::All => Some(ctx.rbp),
         MinidumpContextValidity::Some(ref which) => {
             if !which.contains(STACK_POINTER_REGISTER) {
-                trace!("unwind: cannot scan without stack pointer");
+                trace!("cannot scan without stack pointer");
                 return None;
             }
             if which.contains(FRAME_POINTER_REGISTER) {
@@ -326,7 +326,7 @@ where
             }
 
             trace!(
-                "unwind: scan seems valid -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
+                "scan seems valid -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
                 caller_ip,
                 caller_sp,
             );
@@ -460,14 +460,14 @@ impl Unwind for CONTEXT_AMD64 {
         // if the instruction is within the first ~page of memory, it's basically
         // null, and we can assume unwinding is complete.
         if frame.context.get_instruction_pointer() < 4096 {
-            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            trace!("instruction pointer was nullish, assuming unwind complete");
             return None;
         }
         // If the new stack pointer is at a lower address than the old,
         // then that's clearly incorrect. Treat this as end-of-stack to
         // enforce progress and avoid infinite loops.
         if frame.context.get_stack_pointer() <= self.rsp {
-            trace!("unwind: stack pointer went backwards, assuming unwind complete");
+            trace!("stack pointer went backwards, assuming unwind complete");
             return None;
         }
 

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -56,6 +56,8 @@ impl TestFixture {
         };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
+            0,
+            None,
             &Some(&context),
             Some(&stack_memory),
             &self.modules,

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -8,13 +8,13 @@ use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
 use crate::{SymbolProvider, SystemInfo};
-use log::trace;
 use minidump::system_info::Os;
 use minidump::{
     CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
     MinidumpRawContext,
 };
 use std::collections::HashSet;
+use tracing::trace;
 
 type ArmContext = minidump::format::CONTEXT_ARM;
 type Pointer = <ArmContext as CpuContext>::Register;
@@ -38,7 +38,7 @@ async fn get_caller_by_cfi<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying cfi");
+    trace!("trying cfi");
     let valid = &callee.context.valid;
     let _last_sp = ctx.get_register(STACK_POINTER, valid)?;
     let module = modules.module_at_address(callee.instruction)?;
@@ -69,7 +69,7 @@ where
     let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
 
     trace!(
-        "unwind: cfi evaluation was successful -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
+        "cfi evaluation was successful -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_pc,
         caller_sp,
     );
@@ -118,7 +118,7 @@ where
         return None;
     }
 
-    trace!("unwind: trying frame pointer");
+    trace!("trying frame pointer");
     // Assume that the standard %fp-using ARM calling convention is in use.
     // The main quirk of this ABI is that the return address doesn't need to
     // be restored from the stack -- it's already in the link register (lr).
@@ -165,7 +165,7 @@ where
     // Don't do any more validation, just assume it worked.
 
     trace!(
-        "unwind: frame pointer seems valid -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
+        "frame pointer seems valid -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_pc,
         caller_sp,
     );
@@ -199,7 +199,7 @@ async fn get_caller_by_scan<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying scan");
+    trace!("trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
     // a value on the stack that looks like a pointer into some code (it's an address
     // in a range covered by one of our modules). If we find such an instruction,
@@ -232,7 +232,7 @@ where
             // (that's what breakpad does!)
 
             trace!(
-                "unwind: scan seems valid -- caller_pc: 0x{:08x}, caller_sp: 0x{:08x}",
+                "scan seems valid -- caller_pc: 0x{:08x}, caller_sp: 0x{:08x}",
                 caller_pc,
                 caller_sp,
             );
@@ -347,7 +347,7 @@ impl Unwind for ArmContext {
         // if the instruction is within the first ~page of memory, it's basically
         // null, and we can assume unwinding is complete.
         if frame.context.get_instruction_pointer() < 4096 {
-            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            trace!("instruction pointer was nullish, assuming unwind complete");
             return None;
         }
         // If the new stack pointer is at a lower address than the old,
@@ -363,7 +363,7 @@ impl Unwind for ArmContext {
             // more strict validation to avoid infinite loops.
             let is_leaf = callee.trust == FrameTrust::Context && sp == last_sp;
             if !is_leaf {
-                trace!("unwind: stack pointer went backwards, assuming unwind complete");
+                trace!("stack pointer went backwards, assuming unwind complete");
                 return None;
             }
         }

--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -8,12 +8,12 @@ use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
 use crate::{SymbolProvider, SystemInfo};
-use log::trace;
 use minidump::{
     CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
     MinidumpRawContext, Module,
 };
 use std::collections::HashSet;
+use tracing::trace;
 
 type ArmContext = minidump::format::CONTEXT_ARM64;
 type Pointer = <ArmContext as CpuContext>::Register;
@@ -39,7 +39,7 @@ async fn get_caller_by_cfi<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying cfi");
+    trace!("trying cfi");
 
     let valid = &callee.context.valid;
     let _last_sp = ctx.get_register(STACK_POINTER, valid)?;
@@ -72,7 +72,7 @@ where
     let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
 
     trace!(
-        "unwind: cfi evaluation was successful -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
+        "cfi evaluation was successful -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_pc,
         caller_sp,
     );
@@ -115,7 +115,7 @@ fn get_caller_by_frame_pointer<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying frame pointer");
+    trace!("trying frame pointer");
     // Assume that the standard %fp-using ARM64 calling convention is in use.
     // The main quirk of this ABI is that the return address doesn't need to
     // be restored from the stack -- it's already in the link register (lr).
@@ -174,14 +174,14 @@ where
 
     // Don't accept obviously wrong instruction pointers.
     if is_non_canonical(caller_pc) {
-        trace!("unwind: rejecting frame pointer result for unreasonable instruction pointer");
+        trace!("rejecting frame pointer result for unreasonable instruction pointer");
         return None;
     }
 
     // Don't actually validate that the stack makes sense (duplicating breakpad behaviour).
 
     trace!(
-        "unwind: frame pointer seems valid -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
+        "frame pointer seems valid -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_pc,
         caller_sp,
     );
@@ -281,7 +281,7 @@ fn ptr_auth_strip(modules: &MinidumpModuleList, ptr: Pointer) -> Pointer {
         // a module so we don't start corrupting normal pointers that are just
         // in modules we don't know about.
         if modules.module_at_address(stripped).is_some() {
-            // trace!("unwind: stripped pointer {:016x} -> {:016x}", ptr, stripped);
+            // trace!("stripped pointer {:016x} -> {:016x}", ptr, stripped);
             return stripped;
         }
     }
@@ -299,7 +299,7 @@ async fn get_caller_by_scan<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying scan");
+    trace!("trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
     // a value on the stack that looks like a pointer into some code (it's an address
     // in a range covered by one of our modules). If we find such an instruction,
@@ -332,7 +332,7 @@ where
             // (that's what breakpad does!)
 
             trace!(
-                "unwind: scan seems valid -- caller_pc: 0x{:08x}, caller_sp: 0x{:08x}",
+                "scan seems valid -- caller_pc: 0x{:08x}, caller_sp: 0x{:08x}",
                 caller_pc,
                 caller_sp,
             );
@@ -455,7 +455,7 @@ impl Unwind for ArmContext {
         // if the instruction is within the first ~page of memory, it's basically
         // null, and we can assume unwinding is complete.
         if frame.context.get_instruction_pointer() < 4096 {
-            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            trace!("instruction pointer was nullish, assuming unwind complete");
             return None;
         }
 
@@ -473,7 +473,7 @@ impl Unwind for ArmContext {
             // more strict validation to avoid infinite loops.
             let is_leaf = callee.trust == FrameTrust::Context && sp == last_sp;
             if !is_leaf {
-                trace!("unwind: stack pointer went backwards, assuming unwind complete");
+                trace!("stack pointer went backwards, assuming unwind complete");
                 return None;
             }
         }

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -8,12 +8,12 @@ use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
 use crate::{SymbolProvider, SystemInfo};
-use log::trace;
 use minidump::{
     CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
     MinidumpRawContext, Module,
 };
 use std::collections::HashSet;
+use tracing::trace;
 
 type ArmContext = minidump::format::CONTEXT_ARM64_OLD;
 type Pointer = <ArmContext as CpuContext>::Register;
@@ -39,7 +39,7 @@ async fn get_caller_by_cfi<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying cfi");
+    trace!("trying cfi");
 
     let valid = &callee.context.valid;
     let _last_sp = ctx.get_register(STACK_POINTER, valid)?;
@@ -72,7 +72,7 @@ where
     let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
 
     trace!(
-        "unwind: cfi evaluation was successful -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
+        "cfi evaluation was successful -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_pc,
         caller_sp,
     );
@@ -115,7 +115,7 @@ fn get_caller_by_frame_pointer<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying frame pointer");
+    trace!("trying frame pointer");
     // Assume that the standard %fp-using ARM64 calling convention is in use.
     // The main quirk of this ABI is that the return address doesn't need to
     // be restored from the stack -- it's already in the link register (lr).
@@ -174,14 +174,14 @@ where
 
     // Don't accept obviously wrong instruction pointers.
     if is_non_canonical(caller_pc) {
-        trace!("unwind: rejecting frame pointer result for unreasonable instruction pointer");
+        trace!("rejecting frame pointer result for unreasonable instruction pointer");
         return None;
     }
 
     // Don't actually validate that the stack makes sense (duplicating breakpad behaviour).
 
     trace!(
-        "unwind: frame pointer seems valid -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
+        "frame pointer seems valid -- caller_pc: 0x{:016x}, caller_sp: 0x{:016x}",
         caller_pc,
         caller_sp,
     );
@@ -281,7 +281,7 @@ fn ptr_auth_strip(modules: &MinidumpModuleList, ptr: Pointer) -> Pointer {
         // a module so we don't start corrupting normal pointers that are just
         // in modules we don't know about.
         if modules.module_at_address(stripped).is_some() {
-            // trace!("unwind: stripped pointer {:016x} -> {:016x}", ptr, stripped);
+            // trace!("stripped pointer {:016x} -> {:016x}", ptr, stripped);
             return stripped;
         }
     }
@@ -299,7 +299,7 @@ async fn get_caller_by_scan<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying scan");
+    trace!("trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
     // a value on the stack that looks like a pointer into some code (it's an address
     // in a range covered by one of our modules). If we find such an instruction,
@@ -332,7 +332,7 @@ where
             // (that's what breakpad does!)
 
             trace!(
-                "unwind: scan seems valid -- caller_pc: 0x{:08x}, caller_sp: 0x{:08x}",
+                "scan seems valid -- caller_pc: 0x{:08x}, caller_sp: 0x{:08x}",
                 caller_pc,
                 caller_sp,
             );
@@ -455,7 +455,7 @@ impl Unwind for ArmContext {
         // if the instruction is within the first ~page of memory, it's basically
         // null, and we can assume unwinding is complete.
         if frame.context.get_instruction_pointer() < 4096 {
-            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            trace!("instruction pointer was nullish, assuming unwind complete");
             return None;
         }
 
@@ -473,7 +473,7 @@ impl Unwind for ArmContext {
             // more strict validation to avoid infinite loops.
             let is_leaf = callee.trust == FrameTrust::Context && sp == last_sp;
             if !is_leaf {
-                trace!("unwind: stack pointer went backwards, assuming unwind complete");
+                trace!("stack pointer went backwards, assuming unwind complete");
                 return None;
             }
         }

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -59,6 +59,8 @@ impl TestFixture {
         };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
+            0,
+            None,
             &Some(&context),
             Some(&stack_memory),
             &self.modules,

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -56,6 +56,8 @@ impl TestFixture {
         };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
+            0,
+            None,
             &Some(&context),
             Some(&stack_memory),
             &self.modules,

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -12,9 +12,9 @@ mod x86;
 
 use crate::process_state::*;
 use crate::{FrameWalker, SymbolProvider, SystemInfo};
-use log::trace;
 use minidump::*;
 use scroll::ctx::{SizeWith, TryFromCtx};
+use tracing::trace;
 
 use self::unwind::Unwind;
 use std::collections::HashSet;
@@ -179,7 +179,10 @@ async fn fill_source_line_info<P>(
     }
 }
 
+#[tracing::instrument(name = "unwind", level = "trace", skip_all, fields(tid = thread_id, name = thread_name.unwrap_or("")))]
 pub async fn walk_stack<P>(
+    thread_id: u32,
+    thread_name: Option<&str>,
     maybe_context: &Option<&MinidumpContext>,
     stack_memory: Option<&MinidumpMemory<'_>>,
     modules: &MinidumpModuleList,
@@ -194,17 +197,21 @@ where
     let mut frames = vec![];
     let mut info = CallStackInfo::Ok;
     if let Some(context) = *maybe_context {
-        trace!("unwind: starting stack unwind");
+        trace!(
+            "starting stack unwind of thread {} {}",
+            thread_id,
+            thread_name.unwrap_or("")
+        );
         let ctx = context.clone();
         let mut maybe_frame = Some(StackFrame::from_context(ctx, FrameTrust::Context));
         while let Some(mut frame) = maybe_frame {
             fill_source_line_info(&mut frame, modules, symbol_provider).await;
             trace!(
-                "unwind: unwinding {}",
+                "unwinding {}",
                 frame
                     .function_name
                     .clone()
-                    .unwrap_or_else(|| frame.instruction.to_string())
+                    .unwrap_or_else(|| format!("0x{:08x}", frame.instruction))
             );
             frames.push(frame);
             let callee_frame = &frames.last().unwrap();
@@ -219,7 +226,11 @@ where
             )
             .await;
         }
-        trace!("unwind: finished stack unwind\n");
+        trace!(
+            "finished stack unwind of thread {} {}\n",
+            thread_id,
+            thread_name.unwrap_or("")
+        );
     } else {
         info = CallStackInfo::MissingContext;
     }

--- a/minidump-processor/src/stackwalker/x86.rs
+++ b/minidump-processor/src/stackwalker/x86.rs
@@ -10,13 +10,13 @@ use crate::process_state::{FrameTrust, StackFrame};
 use crate::stackwalker::unwind::Unwind;
 use crate::stackwalker::CfiStackWalker;
 use crate::{SymbolProvider, SystemInfo};
-use log::trace;
 use minidump::format::CONTEXT_X86;
 use minidump::{
     MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
     MinidumpRawContext,
 };
 use std::collections::HashSet;
+use tracing::trace;
 
 type Pointer = u32;
 const POINTER_WIDTH: Pointer = 4;
@@ -36,7 +36,7 @@ async fn get_caller_by_cfi<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying cfi");
+    trace!("trying cfi");
 
     let valid = &callee.context.valid;
     if let MinidumpContextValidity::Some(ref which) = valid {
@@ -74,7 +74,7 @@ where
     let caller_sp = stack_walker.caller_ctx.esp;
 
     trace!(
-        "unwind: cfi evaluation was successful -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
+        "cfi evaluation was successful -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
         caller_ip,
         caller_sp,
     );
@@ -97,7 +97,7 @@ where
     //
     // It also has some weird scanning to try to adjust the computed bp?
 
-    trace!("unwind: cfi result seems valid");
+    trace!("cfi result seems valid");
 
     let context = MinidumpContext {
         raw: MinidumpRawContext::X86(stack_walker.caller_ctx),
@@ -127,7 +127,7 @@ fn get_caller_by_frame_pointer<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying frame pointer");
+    trace!("trying frame pointer");
     if let MinidumpContextValidity::Some(ref which) = callee.context.valid {
         if !which.contains(FRAME_POINTER_REGISTER) {
             return None;
@@ -175,7 +175,7 @@ where
     // desirable.
 
     trace!(
-        "unwind: frame pointer seems valid -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
+        "frame pointer seems valid -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
         caller_ip,
         caller_sp,
     );
@@ -207,7 +207,7 @@ async fn get_caller_by_scan<P>(
 where
     P: SymbolProvider + Sync,
 {
-    trace!("unwind: trying scan");
+    trace!("trying scan");
     // Stack scanning is just walking from the end of the frame until we encounter
     // a value on the stack that looks like a pointer into some code (it's an address
     // in a range covered by one of our modules). If we find such an instruction,
@@ -218,7 +218,7 @@ where
         MinidumpContextValidity::All => Some(ctx.ebp),
         MinidumpContextValidity::Some(ref which) => {
             if !which.contains(STACK_POINTER_REGISTER) {
-                trace!("unwind: cannot scan without stack pointer");
+                trace!("cannot scan without stack pointer");
                 return None;
             }
             if which.contains(FRAME_POINTER_REGISTER) {
@@ -300,7 +300,7 @@ where
             }
 
             trace!(
-                "unwind: scan seems valid -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
+                "scan seems valid -- caller_ip: 0x{:08x}, caller_sp: 0x{:08x}",
                 caller_ip,
                 caller_sp,
             );
@@ -422,14 +422,14 @@ impl Unwind for CONTEXT_X86 {
         // if the instruction is within the first ~page of memory, it's basically
         // null, and we can assume unwinding is complete.
         if frame.context.get_instruction_pointer() < 4096 {
-            trace!("unwind: instruction pointer was nullish, assuming unwind complete");
+            trace!("instruction pointer was nullish, assuming unwind complete");
             return None;
         }
         // If the new stack pointer is at a lower address than the old,
         // then that's clearly incorrect. Treat this as end-of-stack to
         // enforce progress and avoid infinite loops.
         if frame.context.get_stack_pointer() <= self.esp as u64 {
-            trace!("unwind: stack pointer went backwards, assuming unwind complete");
+            trace!("stack pointer went backwards, assuming unwind complete");
             return None;
         }
 

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -55,6 +55,8 @@ impl TestFixture {
         };
         let symbolizer = Symbolizer::new(string_symbol_supplier(self.symbols.clone()));
         walk_stack(
+            0,
+            None,
             &Some(&context),
             Some(&stack_memory),
             &self.modules,

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minidump-stackwalk"
-description = "A CLI minidump analyzer"
+description = "Analyzes minidumps and produces a report (either human-readable or JSON)"
 version = "0.11.0"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"
@@ -15,7 +15,7 @@ edition = "2018"
 travis-ci = { repository = "rust-minidump/rust-minidump" }
 
 [dependencies]
-clap = { version = "3.1", features = ["cargo", "wrap_help"] }
+clap = { version = "3.1", features = ["cargo", "wrap_help", "derive"] }
 log = "0.4"
 minidump = { version = "0.11.0", path = "../minidump" }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -16,14 +16,14 @@ travis-ci = { repository = "rust-minidump/rust-minidump" }
 
 [dependencies]
 clap = { version = "3.1", features = ["cargo", "wrap_help", "derive"] }
-log = "0.4"
 minidump = { version = "0.11.0", path = "../minidump" }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
 minidump-processor = { version = "0.11.0", path = "../minidump-processor", features = [
     "http",
 ] }
-simplelog = "0.12"
 tokio = { version = "1.12.0", features = ["full"] }
+tracing = { version = "0.1.34", features = ["log"] }
+tracing-subscriber = "0.3.11"
 
 [dev-dependencies]
 insta = "1.13.0"

--- a/minidump-stackwalk/README.md
+++ b/minidump-stackwalk/README.md
@@ -164,75 +164,66 @@ Here is an example stackwalking trace:
 
 # minidump-stackwalk CLI manual
 
-> This manual can be regenerated with `minidump-stackwalk --help-markdown please`
+> This manual can be regenerated with `minidump-stackwalk --help-markdown`
 
 Version: `minidump-stackwalk 0.11.0`
 
-Analyzes minidumps and produces a report (either human-readable or JSON).
+Analyzes minidumps and produces a report (either human-readable or JSON)
 
-# USAGE
-
+### USAGE
+```
 minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...
+```
 
-# ARGS
+### ARGS
+#### `<MINIDUMP>`
+Path to the minidump file to analyze
 
-### `<minidump>`
-
-Path to the minidump file to analyze.
-
-### `<symbols-path-legacy>...`
-
+#### `<SYMBOLS_PATH_LEGACY>...`
 Path to a symbol file. (Passed positionally)
 
 If multiple symbols-path-legacy values are provided, all symbol files will be merged
 into minidump-stackwalk's symbol database.
 
-# OPTIONS
-
-### `--json`
-
-Emit a machine-readable JSON report.
-
-The schema for this output is officially documented here:
-https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-
-schema.md
-
-### `--human`
-
-Emit a human-readable report (the default).
+### OPTIONS
+#### `--human`
+Emit a human-readable report (the default)
 
 The human-readable report does not have a specified format, and may not have as many
 details as the JSON format. It is intended for quickly inspecting a crash or debugging
 rust-minidump itself.
 
-### `--cyborg <cyborg>`
+#### `--json`
+Emit a machine-readable JSON report
 
+The schema for this output is officially documented here:
+https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+
+#### `--cyborg <CYBORG>`
 Combine --human and --json
 
 Because this creates two output streams, you must specify a path to write the --json
 output to. The --human output will be the 'primary' output and default to stdout, which
 can be configured with --output-file as normal.
 
-### `--dump`
-
-Dump the 'raw' contents of the minidump.
+#### `--dump`
+Dump the 'raw' contents of the minidump
 
 This is an implementation of the functionality of the old minidump_dump tool. It
 minimally parses and interprets the minidump in an attempt to produce a fairly 'raw'
 dump of the minidump's contents. This is most useful for debugging minidump-stackwalk
 itself, or a misbehaving minidump generator.
 
-### `--features <features>`
+#### `--features <FEATURES>`
+Specify at a high-level how much analysis to perform
 
-Specify at a high-level how much analysis to perform.
-
-This flag provides a way to more blindly opt into Extra Analysis without having to know
-about the specific features of minidump-stackwalk. This is equivalent to
+This flag provides a way to more blindly opt into Extra Analysis without having
+to know about the specific features of minidump-stackwalk. This is equivalent to
 ProcessorOptions in minidump-processor. The current supported values are:
 
-- stable-basic (default): give me solid detailed analysis that most people would want
-- stable-all: turn on extra detailed analysis.
-- unstable-all: turn on the weird and experimental stuff.
+* stable-basic (default): give me solid detailed analysis that most people would want
+* stable-all: turn on extra detailed analysis.
+* unstable-all: turn on the weird and experimental stuff.
 
 stable-all enables: nothing (currently identical to stable-basic)
 
@@ -243,73 +234,70 @@ to introduce new features which may be experimental or expensive. To balance the
 concerns, new features will usually be disabled by default and given a specific flag,
 but still more easily 'discovered' by anyone who uses this flag.
 
-Anyone using minidump-stackwalk who is _really_ worried about the output being stable
+Anyone using minidump-stackwalk who is *really* worried about the output being stable
 should probably not use this flag in production, but its use is recommended for casual
 human usage or for checking "what's new".
 
 Features under unstable-all may be deprecated and become noops. Features which require
 additional input (such as `--evil-json`) cannot be affected by this, and must still be
-manually 'discovered'.[default: stable-basic]
-\[possible values: stable-basic, stable-all, unstable-all]
+manually 'discovered'.
 
-### `--output-file <output-file>`
+\[default: stable-basic]  
+\[possible values: stable-basic, stable-all, unstable-all]  
 
-Where to write the output to (if unspecified, stdout is used)
-
-### `--log-file <log-file>`
-
-Where to write logs to (if unspecified, stderr is used)
-
-### `--verbose <verbose>`
-
-Set the logging level.
+#### `--verbose <VERBOSE>`
+How verbose logging should be (log level)
 
 The unwinder has been heavily instrumented with `trace` logging, so if you want to debug
 why an unwind happened the way it did, --verbose=trace is very useful (all unwinder
-logging will be prefixed with `unwind:`).[default: error]
-\[possible values: off, error, warn, info, debug, trace]
+logging will be prefixed with `unwind:`).
 
-### `--pretty`
+\[default: error]  
+\[possible values: off, error, warn, info, debug, trace]  
 
-Pretty-print --json output.
+#### `--output-file <OUTPUT_FILE>`
+Where to write the output to (if unspecified, stdout is used)
 
-### `--brief`
+#### `--log-file <LOG_FILE>`
+Where to write logs to (if unspecified, stderr is used)
 
-Provide a briefer --human report.
+#### `--pretty`
+Pretty-print --json output
+
+#### `--brief`
+Provide a briefer --human report
 
 Only provides the top-level summary and a backtrace of the crashing thread.
 
-### `--evil-json <evil-json>`
-
+#### `--evil-json <EVIL_JSON>`
 **[UNSTABLE]** An input JSON file with the extra information.
 
 This is a gross hack for some legacy side-channel information that mozilla uses. It will
 hopefully be phased out and deprecated in favour of just using custom streams in the
 minidump itself.
 
-### `--recover-function-args`
-
+#### `--recover-function-args`
 **[UNSTABLE]** Heuristically recover function arguments
 
 This is an experimental feature, which currently only shows up in --human output.
 
-### `--symbols-url <symbols-url>`
+#### `--symbols-url <SYMBOLS_URL>`
+base URL from which URLs to symbol files can be constructed
 
-base URL from which URLs to symbol files can be constructed.
+If multiple symbols-url values are provided, they will each be tried in order until
+one resolves.
 
-If multiple symbols-url values are provided, they will each be tried in order until one
-resolves.
-
-The server the base URL points to is expected to conform to the Tecken symbol server
-protocol. For more details, see the Tecken docs:
+The server the base URL points to is expected to conform to the Tecken
+symbol server protocol. For more details, see the Tecken docs:
 
 https://tecken.readthedocs.io/en/latest/
 
-Example symbols-url value: https://symbols.mozilla.org/
+Example symbols-url values:
+* microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
+* mozilla's symbols-server: https://symbols.mozilla.org/
 
-### `--symbols-cache <symbols-cache>`
-
-A directory in which downloaded symbols can be stored.
+#### `--symbols-cache <SYMBOLS_CACHE>`
+A directory in which downloaded symbols can be stored
 
 Symbol files can be very large, so we recommend placing cached files in your system's
 temp directory so that it can garbage collect unused ones for you. To this end, the
@@ -320,8 +308,7 @@ symbols-cache must be on the same filesystem as symbols-tmp (if that doesn't mea
 anything to you, don't worry about it, you're probably not doing something that will run
 afoul of it).
 
-### `--symbols-tmp <symbols-tmp>`
-
+#### `--symbols-tmp <SYMBOLS_TMP>`
 A directory to use as temp space for downloading symbols.
 
 A temp dir is necessary to allow for multiple rust-minidump instances to share a cache
@@ -336,51 +323,22 @@ symbols-tmp must be on the same filesystem as symbols-cache (if that doesn't mea
 anything to you, don't worry about it, you're probably not doing something that will run
 afoul of it).
 
-### `--symbol-download-timeout-secs <symbol-download-timeout-secs>`
-
-The maximum amount of time (in seconds) a symbol file download is allowed to take.
+#### `--symbols-download-timeout-secs <SYMBOLS_DOWNLOAD_TIMEOUT_SECS>`
+The maximum amount of time (in seconds) a symbol file download is allowed to take
 
 This is necessary to enforce forward progress on misbehaving http responses.
 
-\[default: 1000]
+\[default: 1000]  
 
-### `--symbols-path <symbols-path>`
-
+#### `--symbols-path <SYMBOLS_PATH>`
 Path to a symbol file.
 
 If multiple symbols-path values are provided, all symbol files will be merged into
 minidump-stackwalk's symbol database.
 
-### `-h, --help`
-
+#### `-h, --help`
 Print help information
 
-### `-V, --version`
-
+#### `-V, --version`
 Print version information
 
-# NOTES
-
-## Purpose of Symbols
-
-Symbols are used for two purposes:
-
-1. To fill in more information about each frame of the backtraces. (function names, lines, etc.)
-
-2. To do produce a more _accurate_ backtrace. This is primarily accomplished with call frame
-   information (CFI), but just knowing what parts of a module maps to actual code is also useful!
-
-## Supported Symbol Formats
-
-Currently only breakpad text symbol files are supported, although we hope to eventually support
-native formats like PDB and DWARF as well.
-
-## Breakpad Symbol Files
-
-Breakpad symbol files are basically a simplified version of the information found in native
-debuginfo formats. We recommend using a version of dump_syms to generate them.
-
-See:
-
-- https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
-- mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -142,6 +142,13 @@ struct Cli {
     #[clap(long)]
     log_file: Option<PathBuf>,
 
+    /// Prevent the output/logging from using ANSI coloring
+    ///
+    /// Output written to a file via --log-file, --output-file, or --cyborg
+    /// is always --no-color, so this just forces stdout/stderr printing.
+    #[clap(long)]
+    no_color: bool,
+
     /// Pretty-print --json output
     #[clap(long)]
     pretty: bool,
@@ -255,6 +262,7 @@ async fn main() {
             .with_max_level(cli.verbose)
             .with_target(false)
             .without_time()
+            .with_ansi(!cli.no_color)
             .with_writer(std::io::stderr)
             .init();
     }

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -41,8 +41,8 @@ use tracing::level_filters::LevelFilter;
 /// native debuginfo formats. We recommend using a version of dump_syms to generate them.
 ///
 /// See:
-/// * https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
-/// * mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms
+/// * <https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md>
+/// * mozilla's dump_syms (co-developed with this program): <https://github.com/mozilla/dump_syms>
 #[derive(Parser)]
 #[clap(version, about, long_about = None)]
 #[clap(propagate_version = true)]
@@ -68,7 +68,7 @@ struct Cli {
     /// Emit a machine-readable JSON report
     ///
     /// The schema for this output is officially documented here:
-    /// https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+    /// <https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md>
     #[clap(long)]
     json: bool,
 
@@ -152,7 +152,7 @@ struct Cli {
     #[clap(long)]
     brief: bool,
 
-    /// **[UNSTABLE]** An input JSON file with the extra information.
+    /// **UNSTABLE** An input JSON file with the extra information.
     ///
     /// This is a gross hack for some legacy side-channel information that mozilla uses.
     /// It will hopefully be phased out and deprecated in favour of just using custom
@@ -160,7 +160,7 @@ struct Cli {
     #[clap(long)]
     evil_json: Option<PathBuf>,
 
-    /// **[UNSTABLE]** Heuristically recover function arguments
+    /// **UNSTABLE** Heuristically recover function arguments
     ///
     /// This is an experimental feature, which currently only shows up in --human output.
     #[clap(long)]
@@ -174,11 +174,11 @@ struct Cli {
     /// The server the base URL points to is expected to conform to the Tecken
     /// symbol server protocol. For more details, see the Tecken docs:
     ///
-    /// https://tecken.readthedocs.io/en/latest/
+    /// <https://tecken.readthedocs.io/en/latest/>
     ///
     /// Example symbols-url values:
-    /// * microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
-    /// * mozilla's symbols-server: https://symbols.mozilla.org/
+    /// * microsoft's symbol-server: <https://msdl.microsoft.com/download/symbols/>
+    /// * mozilla's symbols-server: <https://symbols.mozilla.org/>
     #[clap(long)]
     #[clap(verbatim_doc_comment)]
     symbols_url: Vec<String>,

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -1,343 +1,252 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use std::boxed::Box;
-use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::ops::Deref;
 use std::panic;
-use std::path::Path;
-use std::str::FromStr;
 use std::time::Duration;
+use std::{boxed::Box, path::PathBuf};
 
 use minidump::*;
 use minidump_processor::{
     http_symbol_supplier, simple_symbol_supplier, MultiSymbolProvider, ProcessorOptions, Symbolizer,
 };
 
-use clap::{AppSettings, Arg, ArgGroup, Command};
+use clap::{AppSettings, ArgGroup, CommandFactory, Parser};
 use log::error;
 use simplelog::{
     ColorChoice, ConfigBuilder, Level, LevelFilter, TermLogger, TerminalMode, WriteLogger,
 };
 
-fn make_app() -> Command<'static> {
-    Command::new("minidump-stackwalk")
-        .version(clap::crate_version!())
-        .about("Analyzes minidumps and produces a report (either human-readable or JSON).")
-        .next_line_help(true)
-        .setting(AppSettings::DeriveDisplayOrder)
-        .override_usage("minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...")
-        .arg(Arg::new("json").long("json").long_help(
-            "Emit a machine-readable JSON report.
+/// Analyzes minidumps and produces a report (either human-readable or JSON)
+///
+/// NOTES:
+///
+/// Purpose of Symbols:
+///
+/// Symbols are used for two purposes:
+///
+///  1. To fill in more information about each frame of the backtraces. (function names, lines, etc.)
+///  2. To do produce a more *accurate* backtrace. This is primarily accomplished with
+///     call frame information (CFI), but just knowing what parts of a module maps to actual
+///     code is also useful!
+///
+/// Supported Symbol Formats:
+///
+/// Currently only breakpad text symbol files are supported, although we hope to eventually
+/// support native formats like PDB and DWARF as well.
+///
+/// Breakpad Symbol Files:
+///
+/// Breakpad symbol files are basically a simplified version of the information found in
+/// native debuginfo formats. We recommend using a version of dump_syms to generate them.
+///
+/// See:
+/// * https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
+/// * mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms
+#[derive(Parser)]
+#[clap(version, about, long_about = None)]
+#[clap(propagate_version = true)]
+#[clap(group(ArgGroup::new("output-format").args(&[
+    "json",
+    "human",
+    "cyborg",
+    "dump",
+    "help-markdown",
+])))]
+#[clap(override_usage("minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]..."))]
+#[clap(setting(AppSettings::DeriveDisplayOrder))]
+#[clap(verbatim_doc_comment)]
+struct Cli {
+    /// Emit a human-readable report (the default)
+    ///
+    /// The human-readable report does not have a specified format, and may not have as
+    /// many details as the JSON format. It is intended for quickly inspecting
+    /// a crash or debugging rust-minidump itself.
+    #[clap(long)]
+    human: bool,
 
-The schema for this output is officially documented here:
-https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md",
-        ))
-        .arg(Arg::new("human").long("human").long_help(
-            "Emit a human-readable report (the default).
+    /// Emit a machine-readable JSON report
+    ///
+    /// The schema for this output is officially documented here:
+    /// https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+    #[clap(long)]
+    json: bool,
 
-The human-readable report does not have a specified format, and may not have as \
-many details as the JSON format. It is intended for quickly inspecting \
-a crash or debugging rust-minidump itself.",
-        ))
-        .arg(
-            Arg::new("cyborg")
-                .long("cyborg")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .long_help(
-                    "Combine --human and --json
+    /// Combine --human and --json
+    ///
+    /// Because this creates two output streams, you must specify a path to write the --json
+    /// output to. The --human output will be the 'primary' output and default to stdout, which
+    /// can be configured with --output-file as normal.
+    #[clap(long)]
+    cyborg: Option<PathBuf>,
 
-Because this creates two output streams, you must specify a path to write the --json \
-output to. The --human output will be the 'primary' output and default to stdout, which \
-can be configured with --output-file as normal.",
-                ),
-        )
-        .arg(Arg::new("dump").long("dump").long_help(
-            "Dump the 'raw' contents of the minidump.
+    /// Dump the 'raw' contents of the minidump
+    ///
+    /// This is an implementation of the functionality of the old minidump_dump tool.
+    /// It minimally parses and interprets the minidump in an attempt to produce a
+    /// fairly 'raw' dump of the minidump's contents. This is most useful for debugging
+    /// minidump-stackwalk itself, or a misbehaving minidump generator.
+    #[clap(long)]
+    dump: bool,
 
-This is an implementation of the functionality of the old minidump_dump tool. \
-It minimally parses and interprets the minidump in an attempt to produce a \
-fairly 'raw' dump of the minidump's contents. This is most useful for debugging \
-minidump-stackwalk itself, or a misbehaving minidump generator.",
-        ))
-        .arg(
-            Arg::new("help-markdown")
-                .long("help-markdown")
-                .long_help("Print --help but formatted as markdown (used for generating docs)")
-                .hide(true),
-        )
-        .group(ArgGroup::new("output-format").args(&[
-            "json",
-            "human",
-            "cyborg",
-            "dump",
-            "help-markdown",
-        ]))
-        .arg(
-            Arg::new("features")
-                .long("features")
-                .possible_values(&["stable-basic", "stable-all", "unstable-all"])
-                .default_value("stable-basic")
-                .takes_value(true)
-                .long_help(
-                    "Specify at a high-level how much analysis to perform.
+    /// Print --help but formatted as markdown (used for generating docs)
+    #[clap(long, hide = true)]
+    help_markdown: bool,
 
-This flag provides a way to more blindly opt into Extra Analysis without having to know about \
-the specific features of minidump-stackwalk. This is equivalent to ProcessorOptions in \
-minidump-processor. The current supported values are:
+    /// Specify at a high-level how much analysis to perform
+    ///
+    /// This flag provides a way to more blindly opt into Extra Analysis without having
+    /// to know about the specific features of minidump-stackwalk. This is equivalent to
+    /// ProcessorOptions in minidump-processor. The current supported values are:
+    ///  
+    /// * stable-basic (default): give me solid detailed analysis that most people would want
+    /// * stable-all: turn on extra detailed analysis.
+    /// * unstable-all: turn on the weird and experimental stuff.
+    ///  
+    /// stable-all enables: nothing (currently identical to stable-basic)
+    ///  
+    /// unstable-all enables: `--recover-function-args`
+    ///  
+    /// minidump-stackwalk wants to be a reliable and stable tool, but we also want to be able
+    /// to introduce new features which may be experimental or expensive. To balance these two
+    /// concerns, new features will usually be disabled by default and given a specific flag,
+    /// but still more easily 'discovered' by anyone who uses this flag.
+    ///  
+    /// Anyone using minidump-stackwalk who is *really* worried about the output being stable
+    /// should probably not use this flag in production, but its use is recommended for casual
+    /// human usage or for checking "what's new".
+    ///  
+    /// Features under unstable-all may be deprecated and become noops. Features which require
+    /// additional input (such as `--evil-json`) cannot be affected by this, and must still be
+    /// manually 'discovered'.
+    #[clap(long, default_value = "stable-basic")]
+    #[clap(possible_values = ["stable-basic", "stable-all", "unstable-all"])]
+    #[clap(verbatim_doc_comment)]
+    features: String,
 
-* stable-basic (default): give me solid detailed analysis that most people would want
-* stable-all: turn on extra detailed analysis.
-* unstable-all: turn on the weird and experimental stuff.
+    /// How verbose logging should be (log level)
+    ///
+    /// The unwinder has been heavily instrumented with `trace` logging, so if you want to
+    /// debug why an unwind happened the way it did, --verbose=trace is very useful
+    /// (all unwinder logging will be prefixed with `unwind:`).
+    #[clap(long)]
+    #[clap(default_value = "error")]
+    #[clap(possible_values = ["off", "error", "warn", "info", "debug", "trace"])]
+    verbose: LevelFilter,
 
-stable-all enables: nothing (currently identical to stable-basic)
+    /// Where to write the output to (if unspecified, stdout is used)
+    #[clap(long)]
+    output_file: Option<PathBuf>,
 
-unstable-all enables: `--recover-function-args`
+    /// Where to write logs to (if unspecified, stderr is used)
+    #[clap(long)]
+    log_file: Option<PathBuf>,
 
-minidump-stackwalk wants to be a reliable and stable tool, but we also want to be able to \
-introduce new features which may be experimental or expensive. To balance these two concerns, \
-new features will usually be disabled by default and given a specific flag, but still more \
-easily 'discovered' by anyone who uses this flag.
+    /// Pretty-print --json output
+    #[clap(long)]
+    pretty: bool,
 
-Anyone using minidump-stackwalk who is *really* worried about the output being stable \
-should probably not use this flag in production, but its use is recommended for casual
-human usage or for checking \"what's new\".
+    /// Provide a briefer --human report
+    ///
+    /// Only provides the top-level summary and a backtrace of the crashing thread.
+    #[clap(long)]
+    brief: bool,
 
-Features under unstable-all may be deprecated and become noops. Features which require \
-additional input (such as `--evil-json`) cannot be affected by this, and must still be \
-manually 'discovered'.",
-                ),
-        )
-        .arg(
-            Arg::new("output-file")
-                .long("output-file")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .help("Where to write the output to (if unspecified, stdout is used)"),
-        )
-        .arg(
-            Arg::new("log-file")
-                .long("log-file")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .help("Where to write logs to (if unspecified, stderr is used)"),
-        )
-        .arg(
-            Arg::new("verbose")
-                .long("verbose")
-                .possible_values(&["off", "error", "warn", "info", "debug", "trace"])
-                .default_value("error")
-                .takes_value(true)
-                .long_help(
-                    "Set the logging level.
+    /// **[UNSTABLE]** An input JSON file with the extra information.
+    ///
+    /// This is a gross hack for some legacy side-channel information that mozilla uses.
+    /// It will hopefully be phased out and deprecated in favour of just using custom
+    /// streams in the minidump itself.
+    #[clap(long)]
+    evil_json: Option<PathBuf>,
 
-The unwinder has been heavily instrumented with `trace` logging, so if you want to debug why \
-an unwind happened the way it did, --verbose=trace is very useful (all unwinder logging will \
-be prefixed with `unwind:`).",
-                ),
-        )
-        .arg(
-            Arg::new("pretty")
-                .long("pretty")
-                .help("Pretty-print --json output."),
-        )
-        .arg(Arg::new("brief").long("brief").help(
-            "Provide a briefer --human report.
+    /// **[UNSTABLE]** Heuristically recover function arguments
+    ///
+    /// This is an experimental feature, which currently only shows up in --human output.
+    #[clap(long)]
+    recover_function_args: bool,
 
-Only provides the top-level summary and a backtrace of the crashing thread.",
-        ))
-        .arg(
-            Arg::new("evil-json")
-                .long("evil-json")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .long_help(
-                    "**[UNSTABLE]** An input JSON file with the extra information.
+    /// base URL from which URLs to symbol files can be constructed
+    ///
+    /// If multiple symbols-url values are provided, they will each be tried in order until
+    /// one resolves.
+    ///
+    /// The server the base URL points to is expected to conform to the Tecken
+    /// symbol server protocol. For more details, see the Tecken docs:
+    ///
+    /// https://tecken.readthedocs.io/en/latest/
+    ///
+    /// Example symbols-url values:
+    /// * microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
+    /// * mozilla's symbols-server: https://symbols.mozilla.org/
+    #[clap(long)]
+    #[clap(verbatim_doc_comment)]
+    symbols_url: Vec<String>,
 
-This is a gross hack for some legacy side-channel information that mozilla uses. It will \
-hopefully be phased out and deprecated in favour of just using custom streams in the \
-minidump itself.",
-                ),
-        )
-        .arg(
-            Arg::new("recover-function-args")
-                .long("recover-function-args")
-                .help(
-                    "**[UNSTABLE]** Heuristically recover function arguments
+    /// A directory in which downloaded symbols can be stored
+    ///
+    /// Symbol files can be very large, so we recommend placing cached files in your
+    /// system's temp directory so that it can garbage collect unused ones for you.
+    /// To this end, the default value for this flag is a `rust-minidump-cache`
+    /// subdirectory of `std::env::temp_dir()` (usually /tmp/rust-minidump-cache on linux).
+    ///
+    /// symbols-cache must be on the same filesystem as symbols-tmp (if that doesn't
+    /// mean anything to you, don't worry about it, you're probably not doing something
+    /// that will run afoul of it).
+    #[clap(long)]
+    symbols_cache: Option<PathBuf>,
 
-This is an experimental feature, which currently only shows up in --human output.",
-                ),
-        )
-        .arg(
-            Arg::new("symbols-url")
-                .long("symbols-url")
-                .multiple_occurrences(true)
-                .takes_value(true)
-                .long_help(
-                    "base URL from which URLs to symbol files can be constructed.
+    /// A directory to use as temp space for downloading symbols.
+    ///
+    /// A temp dir is necessary to allow for multiple rust-minidump instances to share a
+    /// cache without race conditions. Files to be added to the cache will be constructed
+    /// in this location before being atomically moved to the cache.
+    ///
+    /// If no path is specified, `std::env::temp_dir()` will be used to improve portability.
+    /// See the rust documentation for how to set that value if you wish to use something
+    /// other than your system's default temp directory.
+    ///
+    /// symbols-tmp must be on the same filesystem as symbols-cache (if that doesn't
+    /// mean anything to you, don't worry about it, you're probably not doing something
+    /// that will run afoul of it).
+    #[clap(long)]
+    symbols_tmp: Option<PathBuf>,
 
-If multiple symbols-url values are provided, they will each be tried in order until \
-one resolves.
+    /// The maximum amount of time (in seconds) a symbol file download is allowed to take
+    ///
+    /// This is necessary to enforce forward progress on misbehaving http responses.
+    #[clap(long, default_value_t = 1000)]
+    symbols_download_timeout_secs: u64,
 
-The server the base URL points to is expected to conform to the Tecken \
-symbol server protocol. For more details, see the Tecken docs:
+    /// Path to the minidump file to analyze
+    minidump: PathBuf,
 
-https://tecken.readthedocs.io/en/latest/
+    /// Path to a symbol file.
+    ///
+    /// If multiple symbols-path values are provided, all symbol files will be merged
+    /// into minidump-stackwalk's symbol database.
+    #[clap(long)]
+    symbols_path: Vec<PathBuf>,
 
-Example symbols-url value: https://symbols.mozilla.org/",
-                ),
-        )
-        .arg(
-            Arg::new("symbols-cache")
-                .long("symbols-cache")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .long_help(
-                    "A directory in which downloaded symbols can be stored.
-                    
-Symbol files can be very large, so we recommend placing cached files in your \
-system's temp directory so that it can garbage collect unused ones for you. \
-To this end, the default value for this flag is a `rust-minidump-cache` \
-subdirectory of `std::env::temp_dir()` (usually /tmp/rust-minidump-cache on linux).
-
-symbols-cache must be on the same filesystem as symbols-tmp (if that doesn't mean anything to \
-you, don't worry about it, you're probably not doing something that will run afoul of it).",
-                ),
-        )
-        .arg(
-            Arg::new("symbols-tmp")
-                .long("symbols-tmp")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .long_help(
-                    "A directory to use as temp space for downloading symbols.
-
-A temp dir is necessary to allow for multiple rust-minidump instances to share a cache without \
-race conditions. Files to be added to the cache will be constructed in this location before \
-being atomically moved to the cache.
-
-If no path is specified, `std::env::temp_dir()` will be used to improve portability. \
-See the rust documentation for how to set that value if you wish to use something other than \
-your system's default temp directory.
-
-symbols-tmp must be on the same filesystem as symbols-cache (if that doesn't mean anything to \
-you, don't worry about it, you're probably not doing something that will run afoul of it).",
-                ),
-        )
-        .arg(
-            Arg::new("symbol-download-timeout-secs")
-                .long("symbol-download-timeout-secs")
-                .default_value("1000")
-                .takes_value(true)
-                .help(
-                    "The maximum amount of time (in seconds) a symbol file download is allowed \
-to take.
-
-This is necessary to enforce forward progress on misbehaving http responses.",
-                ),
-        )
-        .arg(
-            Arg::new("minidump")
-                .required_unless_present("help-markdown")
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .help("Path to the minidump file to analyze."),
-        )
-        .arg(
-            Arg::new("symbols-path")
-                .long("symbols-path")
-                .multiple_occurrences(true)
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .long_help(
-                    "Path to a symbol file.
-
-If multiple symbols-path values are provided, all symbol files will be merged \
-into minidump-stackwalk's symbol database.",
-                ),
-        )
-        .arg(
-            Arg::new("symbols-path-legacy")
-                .multiple_values(true)
-                .takes_value(true)
-                .allow_invalid_utf8(true)
-                .long_help(
-                    "Path to a symbol file. (Passed positionally)
-
-If multiple symbols-path-legacy values are provided, all symbol files will be merged \
-into minidump-stackwalk's symbol database.",
-                ),
-        )
-        .after_help(
-            "
-NOTES:
-
-Purpose of Symbols:
-
-  Symbols are used for two purposes:
-
-  1. To fill in more information about each frame of the backtraces. (function names, lines, etc.)
-
-  2. To do produce a more *accurate* backtrace. This is primarily accomplished with \
-call frame information (CFI), but just knowing what parts of a module maps to actual \
-code is also useful!
-
-Supported Symbol Formats:
-
-  Currently only breakpad text symbol files are supported, although we hope to eventually \
-support native formats like PDB and DWARF as well.
-
-Breakpad Symbol Files:
-
-  Breakpad symbol files are basically a simplified version of the information found in \
-native debuginfo formats. We recommend using a version of dump_syms to generate them.
-
-  See:
-    * https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
-    * mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms
-
-",
-        )
+    /// Path to a symbol file. (Passed positionally)
+    ///
+    /// If multiple symbols-path-legacy values are provided, all symbol files will be merged
+    /// into minidump-stackwalk's symbol database.
+    symbols_path_legacy: Vec<PathBuf>,
 }
 
 #[cfg_attr(test, allow(dead_code))]
 #[tokio::main]
 async fn main() {
-    let matches = make_app().get_matches();
-
-    // This is a little hack to generate a markdown version of the --help message,
-    // to be used by rust-minidump devs to regenerate docs. Not officially part
-    // of our public API.
-    if matches.is_present("help-markdown") {
-        print_help_markdown();
-        return;
-    }
-
-    let output_file = matches
-        .value_of_os("output-file")
-        .map(|os_str| Path::new(os_str).to_owned());
-
-    let log_file = matches
-        .value_of_os("log-file")
-        .map(|os_str| Path::new(os_str).to_owned());
-
-    let verbosity = match matches.value_of("verbose").unwrap() {
-        "off" => LevelFilter::Off,
-        "warn" => LevelFilter::Warn,
-        "info" => LevelFilter::Info,
-        "debug" => LevelFilter::Debug,
-        "trace" => LevelFilter::Trace,
-        _ => LevelFilter::Error,
-    };
+    let cli = Cli::parse();
 
     // Init the logger (and make trace logging less noisy)
-    if let Some(log_path) = log_file {
+    if let Some(log_path) = cli.log_file {
         let log_file = File::create(log_path).unwrap();
         let _ = WriteLogger::init(
-            verbosity,
+            cli.verbose,
             ConfigBuilder::new()
                 .set_location_level(LevelFilter::Off)
                 .set_time_level(LevelFilter::Off)
@@ -349,7 +258,7 @@ async fn main() {
         .unwrap();
     } else {
         let _ = TermLogger::init(
-            verbosity,
+            cli.verbose,
             ConfigBuilder::new()
                 .set_location_level(LevelFilter::Off)
                 .set_time_level(LevelFilter::Off)
@@ -385,8 +294,16 @@ async fn main() {
         );
     }));
 
+    // This is a little hack to generate a markdown version of the --help message,
+    // to be used by rust-minidump devs to regenerate docs. Not officially part
+    // of our public API.
+    if cli.help_markdown {
+        print_help_markdown(&mut std::io::stdout()).expect("help-markdown failed");
+        return;
+    }
+
     // Pick the default options
-    let mut options = match matches.value_of("features").unwrap() {
+    let mut options = match &*cli.features {
         "stable-basic" => ProcessorOptions::stable_basic(),
         "stable-all" => ProcessorOptions::stable_all(),
         "unstable-all" => ProcessorOptions::unstable_all(),
@@ -394,95 +311,60 @@ async fn main() {
     };
 
     // Now overload the defaults
-    options.evil_json = matches.value_of_os("evil-json").map(Path::new);
-    if matches.is_present("recover-function-args") {
-        options.recover_function_args = true;
-    }
+    options.evil_json = cli.evil_json.as_deref();
+    options.recover_function_args = cli.recover_function_args;
 
     let temp_dir = std::env::temp_dir();
 
-    let mut symbols_paths = matches
-        .values_of_os("symbols-path")
-        .map(|v| {
-            v.map(|os_str| Path::new(os_str).to_owned())
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_else(Vec::new);
-    let symbols_paths_legacy = matches
-        .values_of_os("symbols-path-legacy")
-        .map(|v| {
-            v.map(|os_str| Path::new(os_str).to_owned())
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_else(Vec::new);
-    symbols_paths.extend(symbols_paths_legacy);
+    let mut symbols_paths = cli.symbols_path;
+    symbols_paths.extend(cli.symbols_path_legacy);
 
     // Default to env::temp_dir()/rust-minidump-cache
-    let symbols_cache = matches
-        .value_of_os("symbols-cache")
-        .map(|os_str| Path::new(os_str).to_owned())
+    let symbols_cache = cli
+        .symbols_cache
         .unwrap_or_else(|| temp_dir.join("rust-minidump-cache"));
 
     // Default to env::temp_dir()
-    let symbols_tmp = matches
-        .value_of_os("symbols-tmp")
-        .map(|os_str| Path::new(os_str).to_owned())
-        .unwrap_or(temp_dir);
+    let symbols_tmp = cli.symbols_tmp.unwrap_or(temp_dir);
 
-    let symbols_urls = matches
-        .values_of("symbols-url")
-        .map(|v| v.map(String::from).collect::<Vec<_>>())
-        .unwrap_or_else(Vec::new);
-
-    let timeout = matches
-        .value_of("symbol-download-timeout-secs")
-        .and_then(|x| u64::from_str(x).ok())
-        .map(Duration::from_secs)
-        .unwrap();
-
-    let minidump_path = matches.value_of_os("minidump").map(Path::new).unwrap();
+    let timeout = Duration::from_secs(cli.symbols_download_timeout_secs);
 
     // Determine the kind of output we're producing -- dump, json, human, or cyborg (both).
     // Although we have a --human argument it's mostly just there to make the documentation
     // more clear. human output is enabled by default, and --json disables it.
     // Mutual exclusion is enforced by an ArgGroup, but it doesn't understand that "human"
     // is the implicit default, so we have to do some munging here.
-    let raw_dump = matches.is_present("dump");
-    let mut json = matches.is_present("json");
     // Human is just enabled if nothing else is
+    let raw_dump = cli.dump;
+    let mut json = cli.json;
     let mut human = !json && !raw_dump;
     // Cyborg is just "desugarred" to --json --human
-    let cyborg = matches.value_of_os("cyborg").map(Path::new);
-
-    if cyborg.is_some() {
+    if cli.cyborg.is_some() {
         human = true;
         json = true;
     }
 
     // Now check if arguments that tweak the output are valid. We can't use
     // Arg::requires because clap doesn't understand --json being implicitly enabled.
-    let pretty = matches.is_present("pretty");
-    let brief = matches.is_present("brief");
-
-    if pretty && !json {
+    if cli.pretty && !json {
         error!("Humans must be hideous! (The --pretty and --human flags cannot both be set)");
         std::process::exit(1);
     }
 
-    if brief && !human {
+    if cli.brief && !human {
         error!("Robots cannot be brief! (The --brief flag is only valid for --human output (or --cyborg)");
         std::process::exit(1);
     }
 
     // Ok now let's do the thing!!!!
 
-    match Minidump::read_path(minidump_path) {
+    match Minidump::read_path(cli.minidump) {
         Ok(dump) => {
             let mut stdout;
             let mut output_f;
-            let cyborg_output_f = cyborg.map(|path| File::create(path).unwrap());
+            let cyborg_output_f = cli.cyborg.map(|path| File::create(path).unwrap());
 
-            let mut output: &mut dyn Write = if let Some(output_path) = output_file {
+            let mut output: &mut dyn Write = if let Some(output_path) = cli.output_file {
                 output_f = File::create(output_path).unwrap();
                 &mut output_f
             } else {
@@ -497,10 +379,10 @@ async fn main() {
 
             let mut provider = MultiSymbolProvider::new();
 
-            if !symbols_urls.is_empty() {
+            if !cli.symbols_url.is_empty() {
                 provider.add(Box::new(Symbolizer::new(http_symbol_supplier(
                     symbols_paths,
-                    symbols_urls,
+                    cli.symbols_url,
                     symbols_cache,
                     symbols_tmp,
                     timeout,
@@ -516,7 +398,7 @@ async fn main() {
                 Ok(state) => {
                     // Print the human output if requested (always uses the "real" output).
                     if human {
-                        if brief {
+                        if cli.brief {
                             state.print_brief(&mut output).unwrap();
                         } else {
                             state.print(&mut output).unwrap();
@@ -526,9 +408,9 @@ async fn main() {
                     // Print the json output if requested (using "cyborg" output if available).
                     if json {
                         if let Some(mut cyborg_output_f) = cyborg_output_f {
-                            state.print_json(&mut cyborg_output_f, pretty).unwrap();
+                            state.print_json(&mut cyborg_output_f, cli.pretty).unwrap();
                         } else {
-                            state.print_json(&mut output, pretty).unwrap();
+                            state.print_json(&mut output, cli.pretty).unwrap();
                         }
                     }
                 }
@@ -545,63 +427,108 @@ async fn main() {
     }
 }
 
-fn print_help_markdown() {
-    let mut help_buf = Vec::new();
-
+fn print_help_markdown(out: &mut dyn Write) -> Result<(), Box<dyn std::error::Error>> {
+    let app_name = "minidump-stackwalk";
+    let pretty_app_name = "minidump-stackwalk";
     // Make a new App to get the help message this time.
-    make_app().write_long_help(&mut help_buf).unwrap();
-    let help = String::from_utf8(help_buf).unwrap();
 
-    println!("# minidump-stackwalk CLI manual");
-    println!();
-    println!("> This manual can be regenerated with `minidump-stackwalk --help-markdown please`");
-    println!();
+    writeln!(out, "# {pretty_app_name} CLI manual")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "> This manual can be regenerated with `{pretty_app_name} --help-markdown`"
+    )?;
+    writeln!(out)?;
 
-    // First line is --version
-    let mut lines = help.lines();
-    println!("Version: `{}`", lines.next().unwrap());
-    println!();
+    let mut cli = Cli::command();
+    let full_command = &mut cli;
+    full_command.build();
+    let mut todo = vec![full_command];
+    let mut is_full_command = true;
 
-    for line in lines {
-        // Use a trailing colon to indicate a heading
-        if let Some(heading) = line.strip_suffix(':') {
-            if !line.starts_with(' ') {
-                // SCREAMING headers are Main headings
-                if heading.to_ascii_uppercase() == heading {
-                    println!("# {}", heading);
-                } else {
-                    println!("## {}", heading);
+    while let Some(command) = todo.pop() {
+        let mut help_buf = Vec::new();
+        command.write_long_help(&mut help_buf).unwrap();
+        let help = String::from_utf8(help_buf).unwrap();
+
+        // First line is --version
+        let mut lines = help.lines();
+        let version_line = lines.next().unwrap();
+        let subcommand_name = command.get_name();
+        let pretty_subcommand_name;
+
+        if is_full_command {
+            pretty_subcommand_name = String::new();
+            writeln!(out, "Version: `{version_line}`")?;
+            writeln!(out)?;
+        } else {
+            pretty_subcommand_name = format!("{pretty_app_name} {subcommand_name} ");
+            // Give subcommands some breathing room
+            writeln!(out, "<br><br><br>")?;
+            writeln!(out, "## {pretty_subcommand_name}")?;
+        }
+
+        let mut in_subcommands_listing = false;
+        let mut in_usage = false;
+        for line in lines {
+            // Use a trailing colon to indicate a heading
+            if let Some(heading) = line.strip_suffix(':') {
+                if !line.starts_with(' ') {
+                    // SCREAMING headers are Main headings
+                    if heading.to_ascii_uppercase() == heading {
+                        in_subcommands_listing = heading == "SUBCOMMANDS";
+                        in_usage = heading == "USAGE";
+
+                        writeln!(out, "### {pretty_subcommand_name}{heading}")?;
+                    } else {
+                        writeln!(out, "### {heading}")?;
+                    }
+                    continue;
                 }
+            }
+
+            if in_subcommands_listing && !line.starts_with("     ") {
+                // subcommand names are list items
+                let own_subcommand_name = line.trim();
+                write!(
+                    out,
+                    "* [{own_subcommand_name}](#{app_name}-{own_subcommand_name}): "
+                )?;
                 continue;
             }
+            // The rest is indented, get rid of that
+            let line = line.trim();
+
+            // Usage strings get wrapped in full code blocks
+            if in_usage && line.starts_with(pretty_app_name) {
+                writeln!(out, "```")?;
+                writeln!(out, "{line}")?;
+                writeln!(out, "```")?;
+                continue;
+            }
+
+            // argument names are subheadings
+            if line.starts_with('-') || line.starts_with('<') {
+                writeln!(out, "#### `{line}`")?;
+                continue;
+            }
+
+            // escape default/value strings
+            if line.starts_with('[') {
+                writeln!(out, "\\{line}  ")?;
+                continue;
+            }
+
+            // Normal paragraph text
+            writeln!(out, "{line}")?;
         }
+        writeln!(out)?;
 
-        // Usage strings get wrapped in full code blocks
-        if line.starts_with("minidump-stackwalk ") {
-            println!("```");
-            println!("{}", line);
-            println!("```");
-            continue;
-        }
-
-        // The rest is indented, get rid of that
-        let line = line.trim();
-
-        // argument names are subheadings
-        if line.starts_with('-') || line.starts_with('<') {
-            println!("### `{}`", line);
-            continue;
-        }
-
-        // escape default/value strings
-        if line.starts_with('[') {
-            println!("\\{}", line);
-            continue;
-        }
-
-        // Normal paragraph text
-        println!("{}", line);
+        todo.extend(command.get_subcommands_mut());
+        is_full_command = false;
     }
+
+    Ok(())
 }
 
 fn print_minidump_dump<'a, T, W>(dump: &Minidump<'a, T>, output: &mut W) -> std::io::Result<()>

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
@@ -30,7 +30,7 @@ OPTIONS:
             Emit a machine-readable JSON report
             
             The schema for this output is officially documented here:
-            https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+            <https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md>
 
         --cyborg <CYBORG>
             Combine --human and --json
@@ -103,14 +103,14 @@ OPTIONS:
             Only provides the top-level summary and a backtrace of the crashing thread.
 
         --evil-json <EVIL_JSON>
-            **[UNSTABLE]** An input JSON file with the extra information.
+            **UNSTABLE** An input JSON file with the extra information.
             
             This is a gross hack for some legacy side-channel information that mozilla uses. It will
             hopefully be phased out and deprecated in favour of just using custom streams in the
             minidump itself.
 
         --recover-function-args
-            **[UNSTABLE]** Heuristically recover function arguments
+            **UNSTABLE** Heuristically recover function arguments
             
             This is an experimental feature, which currently only shows up in --human output.
 
@@ -123,11 +123,11 @@ OPTIONS:
             The server the base URL points to is expected to conform to the Tecken
             symbol server protocol. For more details, see the Tecken docs:
             
-            https://tecken.readthedocs.io/en/latest/
+            <https://tecken.readthedocs.io/en/latest/>
             
             Example symbols-url values:
-            * microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
-            * mozilla's symbols-server: https://symbols.mozilla.org/
+            * microsoft's symbol-server: <https://msdl.microsoft.com/download/symbols/>
+            * mozilla's symbols-server: <https://symbols.mozilla.org/>
 
         --symbols-cache <SYMBOLS_CACHE>
             A directory in which downloaded symbols can be stored

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
@@ -1,39 +1,38 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 465
 expression: stdout
 ---
 minidump-stackwalk 0.11.0
-Analyzes minidumps and produces a report (either human-readable or JSON).
+Analyzes minidumps and produces a report (either human-readable or JSON)
 
 USAGE:
     minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...
 
 ARGS:
-    <minidump>
-            Path to the minidump file to analyze.
+    <MINIDUMP>
+            Path to the minidump file to analyze
 
-    <symbols-path-legacy>...
+    <SYMBOLS_PATH_LEGACY>...
             Path to a symbol file. (Passed positionally)
             
             If multiple symbols-path-legacy values are provided, all symbol files will be merged
             into minidump-stackwalk's symbol database.
 
 OPTIONS:
-        --json
-            Emit a machine-readable JSON report.
-            
-            The schema for this output is officially documented here:
-            https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
-
         --human
-            Emit a human-readable report (the default).
+            Emit a human-readable report (the default)
             
             The human-readable report does not have a specified format, and may not have as many
             details as the JSON format. It is intended for quickly inspecting a crash or debugging
             rust-minidump itself.
 
-        --cyborg <cyborg>
+        --json
+            Emit a machine-readable JSON report
+            
+            The schema for this output is officially documented here:
+            https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+
+        --cyborg <CYBORG>
             Combine --human and --json
             
             Because this creates two output streams, you must specify a path to write the --json
@@ -41,18 +40,18 @@ OPTIONS:
             can be configured with --output-file as normal.
 
         --dump
-            Dump the 'raw' contents of the minidump.
+            Dump the 'raw' contents of the minidump
             
             This is an implementation of the functionality of the old minidump_dump tool. It
             minimally parses and interprets the minidump in an attempt to produce a fairly 'raw'
             dump of the minidump's contents. This is most useful for debugging minidump-stackwalk
             itself, or a misbehaving minidump generator.
 
-        --features <features>
-            Specify at a high-level how much analysis to perform.
+        --features <FEATURES>
+            Specify at a high-level how much analysis to perform
             
-            This flag provides a way to more blindly opt into Extra Analysis without having to know
-            about the specific features of minidump-stackwalk. This is equivalent to
+            This flag provides a way to more blindly opt into Extra Analysis without having
+            to know about the specific features of minidump-stackwalk. This is equivalent to
             ProcessorOptions in minidump-processor. The current supported values are:
             
             * stable-basic (default): give me solid detailed analysis that most people would want
@@ -74,32 +73,36 @@ OPTIONS:
             
             Features under unstable-all may be deprecated and become noops. Features which require
             additional input (such as `--evil-json`) cannot be affected by this, and must still be
-            manually 'discovered'.[default: stable-basic]
+            manually 'discovered'.
+            
+            [default: stable-basic]
             [possible values: stable-basic, stable-all, unstable-all]
 
-        --output-file <output-file>
-            Where to write the output to (if unspecified, stdout is used)
-
-        --log-file <log-file>
-            Where to write logs to (if unspecified, stderr is used)
-
-        --verbose <verbose>
-            Set the logging level.
+        --verbose <VERBOSE>
+            How verbose logging should be (log level)
             
             The unwinder has been heavily instrumented with `trace` logging, so if you want to debug
             why an unwind happened the way it did, --verbose=trace is very useful (all unwinder
-            logging will be prefixed with `unwind:`).[default: error]
+            logging will be prefixed with `unwind:`).
+            
+            [default: error]
             [possible values: off, error, warn, info, debug, trace]
 
+        --output-file <OUTPUT_FILE>
+            Where to write the output to (if unspecified, stdout is used)
+
+        --log-file <LOG_FILE>
+            Where to write logs to (if unspecified, stderr is used)
+
         --pretty
-            Pretty-print --json output.
+            Pretty-print --json output
 
         --brief
-            Provide a briefer --human report.
+            Provide a briefer --human report
             
             Only provides the top-level summary and a backtrace of the crashing thread.
 
-        --evil-json <evil-json>
+        --evil-json <EVIL_JSON>
             **[UNSTABLE]** An input JSON file with the extra information.
             
             This is a gross hack for some legacy side-channel information that mozilla uses. It will
@@ -111,21 +114,23 @@ OPTIONS:
             
             This is an experimental feature, which currently only shows up in --human output.
 
-        --symbols-url <symbols-url>
-            base URL from which URLs to symbol files can be constructed.
+        --symbols-url <SYMBOLS_URL>
+            base URL from which URLs to symbol files can be constructed
             
-            If multiple symbols-url values are provided, they will each be tried in order until one
-            resolves.
+            If multiple symbols-url values are provided, they will each be tried in order until
+            one resolves.
             
-            The server the base URL points to is expected to conform to the Tecken symbol server
-            protocol. For more details, see the Tecken docs:
+            The server the base URL points to is expected to conform to the Tecken
+            symbol server protocol. For more details, see the Tecken docs:
             
             https://tecken.readthedocs.io/en/latest/
             
-            Example symbols-url value: https://symbols.mozilla.org/
+            Example symbols-url values:
+            * microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
+            * mozilla's symbols-server: https://symbols.mozilla.org/
 
-        --symbols-cache <symbols-cache>
-            A directory in which downloaded symbols can be stored.
+        --symbols-cache <SYMBOLS_CACHE>
+            A directory in which downloaded symbols can be stored
             
             Symbol files can be very large, so we recommend placing cached files in your system's
             temp directory so that it can garbage collect unused ones for you. To this end, the
@@ -136,7 +141,7 @@ OPTIONS:
             anything to you, don't worry about it, you're probably not doing something that will run
             afoul of it).
 
-        --symbols-tmp <symbols-tmp>
+        --symbols-tmp <SYMBOLS_TMP>
             A directory to use as temp space for downloading symbols.
             
             A temp dir is necessary to allow for multiple rust-minidump instances to share a cache
@@ -151,14 +156,14 @@ OPTIONS:
             anything to you, don't worry about it, you're probably not doing something that will run
             afoul of it).
 
-        --symbol-download-timeout-secs <symbol-download-timeout-secs>
-            The maximum amount of time (in seconds) a symbol file download is allowed to take.
+        --symbols-download-timeout-secs <SYMBOLS_DOWNLOAD_TIMEOUT_SECS>
+            The maximum amount of time (in seconds) a symbol file download is allowed to take
             
             This is necessary to enforce forward progress on misbehaving http responses.
             
             [default: 1000]
 
-        --symbols-path <symbols-path>
+        --symbols-path <SYMBOLS_PATH>
             Path to a symbol file.
             
             If multiple symbols-path values are provided, all symbol files will be merged into
@@ -169,31 +174,4 @@ OPTIONS:
 
     -V, --version
             Print version information
-
-
-NOTES:
-
-Purpose of Symbols:
-
-  Symbols are used for two purposes:
-
-  1. To fill in more information about each frame of the backtraces. (function names, lines, etc.)
-
-  2. To do produce a more *accurate* backtrace. This is primarily accomplished with call frame
-information (CFI), but just knowing what parts of a module maps to actual code is also useful!
-
-Supported Symbol Formats:
-
-  Currently only breakpad text symbol files are supported, although we hope to eventually support
-native formats like PDB and DWARF as well.
-
-Breakpad Symbol Files:
-
-  Breakpad symbol files are basically a simplified version of the information found in native
-debuginfo formats. We recommend using a version of dump_syms to generate them.
-
-  See:
-    * https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
-    * mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms
-
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
@@ -94,6 +94,12 @@ OPTIONS:
         --log-file <LOG_FILE>
             Where to write logs to (if unspecified, stderr is used)
 
+        --no-color
+            Prevent the output/logging from using ANSI coloring
+            
+            Output written to a file via --log-file, --output-file, or --cyborg is always
+            --no-color, so this just forces stdout/stderr printing.
+
         --pretty
             Pretty-print --json output
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
@@ -101,6 +101,12 @@ Where to write the output to (if unspecified, stdout is used)
 #### `--log-file <LOG_FILE>`
 Where to write logs to (if unspecified, stderr is used)
 
+#### `--no-color`
+Prevent the output/logging from using ANSI coloring
+
+Output written to a file via --log-file, --output-file, or --cyborg is always
+#### `--no-color, so this just forces stdout/stderr printing.`
+
 #### `--pretty`
 Pretty-print --json output
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
@@ -1,63 +1,64 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 502
 expression: stdout
 ---
 # minidump-stackwalk CLI manual
 
-> This manual can be regenerated with `minidump-stackwalk --help-markdown please`
+> This manual can be regenerated with `minidump-stackwalk --help-markdown`
 
 Version: `minidump-stackwalk 0.11.0`
 
-Analyzes minidumps and produces a report (either human-readable or JSON).
+Analyzes minidumps and produces a report (either human-readable or JSON)
 
-# USAGE
+### USAGE
+```
 minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...
+```
 
-# ARGS
-### `<minidump>`
-Path to the minidump file to analyze.
+### ARGS
+#### `<MINIDUMP>`
+Path to the minidump file to analyze
 
-### `<symbols-path-legacy>...`
+#### `<SYMBOLS_PATH_LEGACY>...`
 Path to a symbol file. (Passed positionally)
 
 If multiple symbols-path-legacy values are provided, all symbol files will be merged
 into minidump-stackwalk's symbol database.
 
-# OPTIONS
-### `--json`
-Emit a machine-readable JSON report.
-
-The schema for this output is officially documented here:
-https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
-
-### `--human`
-Emit a human-readable report (the default).
+### OPTIONS
+#### `--human`
+Emit a human-readable report (the default)
 
 The human-readable report does not have a specified format, and may not have as many
 details as the JSON format. It is intended for quickly inspecting a crash or debugging
 rust-minidump itself.
 
-### `--cyborg <cyborg>`
+#### `--json`
+Emit a machine-readable JSON report
+
+The schema for this output is officially documented here:
+https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+
+#### `--cyborg <CYBORG>`
 Combine --human and --json
 
 Because this creates two output streams, you must specify a path to write the --json
 output to. The --human output will be the 'primary' output and default to stdout, which
 can be configured with --output-file as normal.
 
-### `--dump`
-Dump the 'raw' contents of the minidump.
+#### `--dump`
+Dump the 'raw' contents of the minidump
 
 This is an implementation of the functionality of the old minidump_dump tool. It
 minimally parses and interprets the minidump in an attempt to produce a fairly 'raw'
 dump of the minidump's contents. This is most useful for debugging minidump-stackwalk
 itself, or a misbehaving minidump generator.
 
-### `--features <features>`
-Specify at a high-level how much analysis to perform.
+#### `--features <FEATURES>`
+Specify at a high-level how much analysis to perform
 
-This flag provides a way to more blindly opt into Extra Analysis without having to know
-about the specific features of minidump-stackwalk. This is equivalent to
+This flag provides a way to more blindly opt into Extra Analysis without having
+to know about the specific features of minidump-stackwalk. This is equivalent to
 ProcessorOptions in minidump-processor. The current supported values are:
 
 * stable-basic (default): give me solid detailed analysis that most people would want
@@ -79,58 +80,64 @@ human usage or for checking "what's new".
 
 Features under unstable-all may be deprecated and become noops. Features which require
 additional input (such as `--evil-json`) cannot be affected by this, and must still be
-manually 'discovered'.[default: stable-basic]
-\[possible values: stable-basic, stable-all, unstable-all]
+manually 'discovered'.
 
-### `--output-file <output-file>`
-Where to write the output to (if unspecified, stdout is used)
+\[default: stable-basic]  
+\[possible values: stable-basic, stable-all, unstable-all]  
 
-### `--log-file <log-file>`
-Where to write logs to (if unspecified, stderr is used)
-
-### `--verbose <verbose>`
-Set the logging level.
+#### `--verbose <VERBOSE>`
+How verbose logging should be (log level)
 
 The unwinder has been heavily instrumented with `trace` logging, so if you want to debug
 why an unwind happened the way it did, --verbose=trace is very useful (all unwinder
-logging will be prefixed with `unwind:`).[default: error]
-\[possible values: off, error, warn, info, debug, trace]
+logging will be prefixed with `unwind:`).
 
-### `--pretty`
-Pretty-print --json output.
+\[default: error]  
+\[possible values: off, error, warn, info, debug, trace]  
 
-### `--brief`
-Provide a briefer --human report.
+#### `--output-file <OUTPUT_FILE>`
+Where to write the output to (if unspecified, stdout is used)
+
+#### `--log-file <LOG_FILE>`
+Where to write logs to (if unspecified, stderr is used)
+
+#### `--pretty`
+Pretty-print --json output
+
+#### `--brief`
+Provide a briefer --human report
 
 Only provides the top-level summary and a backtrace of the crashing thread.
 
-### `--evil-json <evil-json>`
+#### `--evil-json <EVIL_JSON>`
 **[UNSTABLE]** An input JSON file with the extra information.
 
 This is a gross hack for some legacy side-channel information that mozilla uses. It will
 hopefully be phased out and deprecated in favour of just using custom streams in the
 minidump itself.
 
-### `--recover-function-args`
+#### `--recover-function-args`
 **[UNSTABLE]** Heuristically recover function arguments
 
 This is an experimental feature, which currently only shows up in --human output.
 
-### `--symbols-url <symbols-url>`
-base URL from which URLs to symbol files can be constructed.
+#### `--symbols-url <SYMBOLS_URL>`
+base URL from which URLs to symbol files can be constructed
 
-If multiple symbols-url values are provided, they will each be tried in order until one
-resolves.
+If multiple symbols-url values are provided, they will each be tried in order until
+one resolves.
 
-The server the base URL points to is expected to conform to the Tecken symbol server
-protocol. For more details, see the Tecken docs:
+The server the base URL points to is expected to conform to the Tecken
+symbol server protocol. For more details, see the Tecken docs:
 
 https://tecken.readthedocs.io/en/latest/
 
-Example symbols-url value: https://symbols.mozilla.org/
+Example symbols-url values:
+* microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
+* mozilla's symbols-server: https://symbols.mozilla.org/
 
-### `--symbols-cache <symbols-cache>`
-A directory in which downloaded symbols can be stored.
+#### `--symbols-cache <SYMBOLS_CACHE>`
+A directory in which downloaded symbols can be stored
 
 Symbol files can be very large, so we recommend placing cached files in your system's
 temp directory so that it can garbage collect unused ones for you. To this end, the
@@ -141,7 +148,7 @@ symbols-cache must be on the same filesystem as symbols-tmp (if that doesn't mea
 anything to you, don't worry about it, you're probably not doing something that will run
 afoul of it).
 
-### `--symbols-tmp <symbols-tmp>`
+#### `--symbols-tmp <SYMBOLS_TMP>`
 A directory to use as temp space for downloading symbols.
 
 A temp dir is necessary to allow for multiple rust-minidump instances to share a cache
@@ -156,49 +163,23 @@ symbols-tmp must be on the same filesystem as symbols-cache (if that doesn't mea
 anything to you, don't worry about it, you're probably not doing something that will run
 afoul of it).
 
-### `--symbol-download-timeout-secs <symbol-download-timeout-secs>`
-The maximum amount of time (in seconds) a symbol file download is allowed to take.
+#### `--symbols-download-timeout-secs <SYMBOLS_DOWNLOAD_TIMEOUT_SECS>`
+The maximum amount of time (in seconds) a symbol file download is allowed to take
 
 This is necessary to enforce forward progress on misbehaving http responses.
 
-\[default: 1000]
+\[default: 1000]  
 
-### `--symbols-path <symbols-path>`
+#### `--symbols-path <SYMBOLS_PATH>`
 Path to a symbol file.
 
 If multiple symbols-path values are provided, all symbol files will be merged into
 minidump-stackwalk's symbol database.
 
-### `-h, --help`
+#### `-h, --help`
 Print help information
 
-### `-V, --version`
+#### `-V, --version`
 Print version information
-
-
-# NOTES
-
-## Purpose of Symbols
-
-Symbols are used for two purposes:
-
-1. To fill in more information about each frame of the backtraces. (function names, lines, etc.)
-
-2. To do produce a more *accurate* backtrace. This is primarily accomplished with call frame
-information (CFI), but just knowing what parts of a module maps to actual code is also useful!
-
-## Supported Symbol Formats
-
-Currently only breakpad text symbol files are supported, although we hope to eventually support
-native formats like PDB and DWARF as well.
-
-## Breakpad Symbol Files
-
-Breakpad symbol files are basically a simplified version of the information found in native
-debuginfo formats. We recommend using a version of dump_syms to generate them.
-
-See:
-* https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
-* mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms
 
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
@@ -37,7 +37,7 @@ rust-minidump itself.
 Emit a machine-readable JSON report
 
 The schema for this output is officially documented here:
-https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
+#### `<https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md>`
 
 #### `--cyborg <CYBORG>`
 Combine --human and --json
@@ -110,14 +110,14 @@ Provide a briefer --human report
 Only provides the top-level summary and a backtrace of the crashing thread.
 
 #### `--evil-json <EVIL_JSON>`
-**[UNSTABLE]** An input JSON file with the extra information.
+**UNSTABLE** An input JSON file with the extra information.
 
 This is a gross hack for some legacy side-channel information that mozilla uses. It will
 hopefully be phased out and deprecated in favour of just using custom streams in the
 minidump itself.
 
 #### `--recover-function-args`
-**[UNSTABLE]** Heuristically recover function arguments
+**UNSTABLE** Heuristically recover function arguments
 
 This is an experimental feature, which currently only shows up in --human output.
 
@@ -130,11 +130,11 @@ one resolves.
 The server the base URL points to is expected to conform to the Tecken
 symbol server protocol. For more details, see the Tecken docs:
 
-https://tecken.readthedocs.io/en/latest/
+#### `<https://tecken.readthedocs.io/en/latest/>`
 
 Example symbols-url values:
-* microsoft's symbol-server: https://msdl.microsoft.com/download/symbols/
-* mozilla's symbols-server: https://symbols.mozilla.org/
+* microsoft's symbol-server: <https://msdl.microsoft.com/download/symbols/>
+* mozilla's symbols-server: <https://symbols.mozilla.org/>
 
 #### `--symbols-cache <SYMBOLS_CACHE>`
 A directory in which downloaded symbols can be stored

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
@@ -1,198 +1,75 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 483
 expression: stdout
 ---
 minidump-stackwalk 0.11.0
-Analyzes minidumps and produces a report (either human-readable or JSON).
+Analyzes minidumps and produces a report (either human-readable or JSON)
 
 USAGE:
     minidump-stackwalk [FLAGS] [OPTIONS] <minidump> [--] [symbols-path]...
 
 ARGS:
-    <minidump>
-            Path to the minidump file to analyze.
-
-    <symbols-path-legacy>...
-            Path to a symbol file. (Passed positionally)
-            
-            If multiple symbols-path-legacy values are provided, all symbol files will be merged
-            into minidump-stackwalk's symbol database.
+    <MINIDUMP>                  Path to the minidump file to analyze
+    <SYMBOLS_PATH_LEGACY>...    Path to a symbol file. (Passed positionally)
 
 OPTIONS:
-        --json
-            Emit a machine-readable JSON report.
-            
-            The schema for this output is officially documented here:
-            https://github.com/rust-minidump/rust-minidump/blob/master/minidump-processor/json-schema.md
-
         --human
-            Emit a human-readable report (the default).
-            
-            The human-readable report does not have a specified format, and may not have as many
-            details as the JSON format. It is intended for quickly inspecting a crash or debugging
-            rust-minidump itself.
+            Emit a human-readable report (the default)
 
-        --cyborg <cyborg>
+        --json
+            Emit a machine-readable JSON report
+
+        --cyborg <CYBORG>
             Combine --human and --json
-            
-            Because this creates two output streams, you must specify a path to write the --json
-            output to. The --human output will be the 'primary' output and default to stdout, which
-            can be configured with --output-file as normal.
 
         --dump
-            Dump the 'raw' contents of the minidump.
-            
-            This is an implementation of the functionality of the old minidump_dump tool. It
-            minimally parses and interprets the minidump in an attempt to produce a fairly 'raw'
-            dump of the minidump's contents. This is most useful for debugging minidump-stackwalk
-            itself, or a misbehaving minidump generator.
+            Dump the 'raw' contents of the minidump
 
-        --features <features>
-            Specify at a high-level how much analysis to perform.
-            
-            This flag provides a way to more blindly opt into Extra Analysis without having to know
-            about the specific features of minidump-stackwalk. This is equivalent to
-            ProcessorOptions in minidump-processor. The current supported values are:
-            
-            * stable-basic (default): give me solid detailed analysis that most people would want
-            * stable-all: turn on extra detailed analysis.
-            * unstable-all: turn on the weird and experimental stuff.
-            
-            stable-all enables: nothing (currently identical to stable-basic)
-            
-            unstable-all enables: `--recover-function-args`
-            
-            minidump-stackwalk wants to be a reliable and stable tool, but we also want to be able
-            to introduce new features which may be experimental or expensive. To balance these two
-            concerns, new features will usually be disabled by default and given a specific flag,
-            but still more easily 'discovered' by anyone who uses this flag.
-            
-            Anyone using minidump-stackwalk who is *really* worried about the output being stable
-            should probably not use this flag in production, but its use is recommended for casual
-            human usage or for checking "what's new".
-            
-            Features under unstable-all may be deprecated and become noops. Features which require
-            additional input (such as `--evil-json`) cannot be affected by this, and must still be
-            manually 'discovered'.[default: stable-basic] [possible values: stable-basic,
-            stable-all, unstable-all]
+        --features <FEATURES>
+            Specify at a high-level how much analysis to perform [default: stable-basic] [possible
+            values: stable-basic, stable-all, unstable-all]
 
-        --output-file <output-file>
-            Where to write the output to (if unspecified, stdout is used)
-
-        --log-file <log-file>
-            Where to write logs to (if unspecified, stderr is used)
-
-        --verbose <verbose>
-            Set the logging level.
-            
-            The unwinder has been heavily instrumented with `trace` logging, so if you want to debug
-            why an unwind happened the way it did, --verbose=trace is very useful (all unwinder
-            logging will be prefixed with `unwind:`).[default: error] [possible values: off, error,
+        --verbose <VERBOSE>
+            How verbose logging should be (log level) [default: error] [possible values: off, error,
             warn, info, debug, trace]
 
+        --output-file <OUTPUT_FILE>
+            Where to write the output to (if unspecified, stdout is used)
+
+        --log-file <LOG_FILE>
+            Where to write logs to (if unspecified, stderr is used)
+
         --pretty
-            Pretty-print --json output.
+            Pretty-print --json output
 
         --brief
-            Provide a briefer --human report.
-            
-            Only provides the top-level summary and a backtrace of the crashing thread.
+            Provide a briefer --human report
 
-        --evil-json <evil-json>
-            **[UNSTABLE]** An input JSON file with the extra information.
-            
-            This is a gross hack for some legacy side-channel information that mozilla uses. It will
-            hopefully be phased out and deprecated in favour of just using custom streams in the
-            minidump itself.
+        --evil-json <EVIL_JSON>
+            **[UNSTABLE]** An input JSON file with the extra information
 
         --recover-function-args
             **[UNSTABLE]** Heuristically recover function arguments
-            
-            This is an experimental feature, which currently only shows up in --human output.
 
-        --symbols-url <symbols-url>
-            base URL from which URLs to symbol files can be constructed.
-            
-            If multiple symbols-url values are provided, they will each be tried in order until one
-            resolves.
-            
-            The server the base URL points to is expected to conform to the Tecken symbol server
-            protocol. For more details, see the Tecken docs:
-            
-            https://tecken.readthedocs.io/en/latest/
-            
-            Example symbols-url value: https://symbols.mozilla.org/
+        --symbols-url <SYMBOLS_URL>
+            base URL from which URLs to symbol files can be constructed
 
-        --symbols-cache <symbols-cache>
-            A directory in which downloaded symbols can be stored.
-            
-            Symbol files can be very large, so we recommend placing cached files in your system's
-            temp directory so that it can garbage collect unused ones for you. To this end, the
-            default value for this flag is a `rust-minidump-cache` subdirectory of
-            `std::env::temp_dir()` (usually /tmp/rust-minidump-cache on linux).
-            
-            symbols-cache must be on the same filesystem as symbols-tmp (if that doesn't mean
-            anything to you, don't worry about it, you're probably not doing something that will run
-            afoul of it).
+        --symbols-cache <SYMBOLS_CACHE>
+            A directory in which downloaded symbols can be stored
 
-        --symbols-tmp <symbols-tmp>
-            A directory to use as temp space for downloading symbols.
-            
-            A temp dir is necessary to allow for multiple rust-minidump instances to share a cache
-            without race conditions. Files to be added to the cache will be constructed in this
-            location before being atomically moved to the cache.
-            
-            If no path is specified, `std::env::temp_dir()` will be used to improve portability. See
-            the rust documentation for how to set that value if you wish to use something other than
-            your system's default temp directory.
-            
-            symbols-tmp must be on the same filesystem as symbols-cache (if that doesn't mean
-            anything to you, don't worry about it, you're probably not doing something that will run
-            afoul of it).
+        --symbols-tmp <SYMBOLS_TMP>
+            A directory to use as temp space for downloading symbols
 
-        --symbol-download-timeout-secs <symbol-download-timeout-secs>
-            The maximum amount of time (in seconds) a symbol file download is allowed to take.
-            
-            This is necessary to enforce forward progress on misbehaving http responses. [default:
-            1000]
+        --symbols-download-timeout-secs <SYMBOLS_DOWNLOAD_TIMEOUT_SECS>
+            The maximum amount of time (in seconds) a symbol file download is allowed to take
+            [default: 1000]
 
-        --symbols-path <symbols-path>
-            Path to a symbol file.
-            
-            If multiple symbols-path values are provided, all symbol files will be merged into
-            minidump-stackwalk's symbol database.
+        --symbols-path <SYMBOLS_PATH>
+            Path to a symbol file
 
     -h, --help
             Print help information
 
     -V, --version
             Print version information
-
-
-NOTES:
-
-Purpose of Symbols:
-
-  Symbols are used for two purposes:
-
-  1. To fill in more information about each frame of the backtraces. (function names, lines, etc.)
-
-  2. To do produce a more *accurate* backtrace. This is primarily accomplished with call frame
-information (CFI), but just knowing what parts of a module maps to actual code is also useful!
-
-Supported Symbol Formats:
-
-  Currently only breakpad text symbol files are supported, although we hope to eventually support
-native formats like PDB and DWARF as well.
-
-Breakpad Symbol Files:
-
-  Breakpad symbol files are basically a simplified version of the information found in native
-debuginfo formats. We recommend using a version of dump_syms to generate them.
-
-  See:
-    * https://chromium.googlesource.com/breakpad/breakpad/+/master/docs/symbol_files.md
-    * mozilla's dump_syms (co-developed with this program): https://github.com/mozilla/dump_syms
-
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
@@ -46,10 +46,10 @@ OPTIONS:
             Provide a briefer --human report
 
         --evil-json <EVIL_JSON>
-            **[UNSTABLE]** An input JSON file with the extra information
+            **UNSTABLE** An input JSON file with the extra information
 
         --recover-function-args
-            **[UNSTABLE]** Heuristically recover function arguments
+            **UNSTABLE** Heuristically recover function arguments
 
         --symbols-url <SYMBOLS_URL>
             base URL from which URLs to symbol files can be constructed

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
@@ -39,6 +39,9 @@ OPTIONS:
         --log-file <LOG_FILE>
             Where to write logs to (if unspecified, stderr is used)
 
+        --no-color
+            Prevent the output/logging from using ANSI coloring
+
         --pretty
             Pretty-print --json output
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__trace.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__trace.snap
@@ -1,26 +1,26 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-expression: stderr
+expression: log
 ---
-[33m WARN[0m Minidump contains multiple streams of type 0 (UnusedStream) at indices 7 (0 bytes) and 8 (0 bytes) (using 8)
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m starting stack unwind of thread 3060 
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x0040429e
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x00404200, caller_sp: 0x0012fe90
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x004041ff
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x004053ec, caller_sp: 0x0012ff78
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x004053eb
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x7c816fd7, caller_sp: 0x0012ffc8
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x7c816fd6
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x00000000, caller_sp: 0x0012fff8
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m instruction pointer was nullish, assuming unwind complete
-[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m finished stack unwind of thread 3060 
+ WARN Minidump contains multiple streams of type 0 (UnusedStream) at indices 7 (0 bytes) and 8 (0 bytes) (using 8)
+TRACE unwind{tid=3060 name=""}: starting stack unwind of thread 3060 
+TRACE unwind{tid=3060 name=""}: unwinding 0x0040429e
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x00404200, caller_sp: 0x0012fe90
+TRACE unwind{tid=3060 name=""}: unwinding 0x004041ff
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x004053ec, caller_sp: 0x0012ff78
+TRACE unwind{tid=3060 name=""}: unwinding 0x004053eb
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x7c816fd7, caller_sp: 0x0012ffc8
+TRACE unwind{tid=3060 name=""}: unwinding 0x7c816fd6
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x00000000, caller_sp: 0x0012fff8
+TRACE unwind{tid=3060 name=""}: instruction pointer was nullish, assuming unwind complete
+TRACE unwind{tid=3060 name=""}: finished stack unwind of thread 3060 
 
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__trace.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__trace.snap
@@ -1,27 +1,26 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
 expression: log
-
 ---
-[WARN] Minidump contains multiple streams of type 0 (UnusedStream) at indices 7 (0 bytes) and 8 (0 bytes) (using 8)
-[TRACE] unwind: starting stack unwind
-[TRACE] unwind: unwinding 4211358
-[TRACE] unwind: trying cfi
-[TRACE] unwind: trying frame pointer
-[TRACE] unwind: frame pointer seems valid -- caller_ip: 0x00404200, caller_sp: 0x0012fe90
-[TRACE] unwind: unwinding 4211199
-[TRACE] unwind: trying cfi
-[TRACE] unwind: trying frame pointer
-[TRACE] unwind: frame pointer seems valid -- caller_ip: 0x004053ec, caller_sp: 0x0012ff78
-[TRACE] unwind: unwinding 4215787
-[TRACE] unwind: trying cfi
-[TRACE] unwind: trying frame pointer
-[TRACE] unwind: frame pointer seems valid -- caller_ip: 0x7c816fd7, caller_sp: 0x0012ffc8
-[TRACE] unwind: unwinding 2088857558
-[TRACE] unwind: trying cfi
-[TRACE] unwind: trying frame pointer
-[TRACE] unwind: frame pointer seems valid -- caller_ip: 0x00000000, caller_sp: 0x0012fff8
-[TRACE] unwind: instruction pointer was nullish, assuming unwind complete
-[TRACE] unwind: finished stack unwind
+ WARN Minidump contains multiple streams of type 0 (UnusedStream) at indices 7 (0 bytes) and 8 (0 bytes) (using 8)
+TRACE unwind{tid=3060 name=""}: starting stack unwind of thread 3060 
+TRACE unwind{tid=3060 name=""}: unwinding 0x0040429e
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x00404200, caller_sp: 0x0012fe90
+TRACE unwind{tid=3060 name=""}: unwinding 0x004041ff
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x004053ec, caller_sp: 0x0012ff78
+TRACE unwind{tid=3060 name=""}: unwinding 0x004053eb
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x7c816fd7, caller_sp: 0x0012ffc8
+TRACE unwind{tid=3060 name=""}: unwinding 0x7c816fd6
+TRACE unwind{tid=3060 name=""}: trying cfi
+TRACE unwind{tid=3060 name=""}: trying frame pointer
+TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x00000000, caller_sp: 0x0012fff8
+TRACE unwind{tid=3060 name=""}: instruction pointer was nullish, assuming unwind complete
+TRACE unwind{tid=3060 name=""}: finished stack unwind of thread 3060 
 
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__trace.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__trace.snap
@@ -1,26 +1,26 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-expression: log
+expression: stderr
 ---
- WARN Minidump contains multiple streams of type 0 (UnusedStream) at indices 7 (0 bytes) and 8 (0 bytes) (using 8)
-TRACE unwind{tid=3060 name=""}: starting stack unwind of thread 3060 
-TRACE unwind{tid=3060 name=""}: unwinding 0x0040429e
-TRACE unwind{tid=3060 name=""}: trying cfi
-TRACE unwind{tid=3060 name=""}: trying frame pointer
-TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x00404200, caller_sp: 0x0012fe90
-TRACE unwind{tid=3060 name=""}: unwinding 0x004041ff
-TRACE unwind{tid=3060 name=""}: trying cfi
-TRACE unwind{tid=3060 name=""}: trying frame pointer
-TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x004053ec, caller_sp: 0x0012ff78
-TRACE unwind{tid=3060 name=""}: unwinding 0x004053eb
-TRACE unwind{tid=3060 name=""}: trying cfi
-TRACE unwind{tid=3060 name=""}: trying frame pointer
-TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x7c816fd7, caller_sp: 0x0012ffc8
-TRACE unwind{tid=3060 name=""}: unwinding 0x7c816fd6
-TRACE unwind{tid=3060 name=""}: trying cfi
-TRACE unwind{tid=3060 name=""}: trying frame pointer
-TRACE unwind{tid=3060 name=""}: frame pointer seems valid -- caller_ip: 0x00000000, caller_sp: 0x0012fff8
-TRACE unwind{tid=3060 name=""}: instruction pointer was nullish, assuming unwind complete
-TRACE unwind{tid=3060 name=""}: finished stack unwind of thread 3060 
+[33m WARN[0m Minidump contains multiple streams of type 0 (UnusedStream) at indices 7 (0 bytes) and 8 (0 bytes) (using 8)
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m starting stack unwind of thread 3060 
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x0040429e
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x00404200, caller_sp: 0x0012fe90
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x004041ff
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x004053ec, caller_sp: 0x0012ff78
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x004053eb
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x7c816fd7, caller_sp: 0x0012ffc8
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m unwinding 0x7c816fd6
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying cfi
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m trying frame pointer
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m frame pointer seems valid -- caller_ip: 0x00000000, caller_sp: 0x0012fff8
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m instruction pointer was nullish, assuming unwind complete
+[35mTRACE[0m [1munwind[0m[1m{[0m[3mtid[0m[2m=[0m3060 [3mname[0m[2m=[0m""[1m}[0m[2m:[0m finished stack unwind of thread 3060 
 
 

--- a/minidump-stackwalk/tests/test-minidump-stackwalk.rs
+++ b/minidump-stackwalk/tests/test-minidump-stackwalk.rs
@@ -365,8 +365,8 @@ fn test_trace() {
     let output = Command::new(bin)
         .arg("--human")
         .arg("--verbose=trace")
+        .arg("--no-color") // disable coloured output for logs
         .arg("../testdata/test.dmp")
-        .env("NO_COLOR", "1") // disable coloured output for logs
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()

--- a/minidump-stackwalk/tests/test-minidump-stackwalk.rs
+++ b/minidump-stackwalk/tests/test-minidump-stackwalk.rs
@@ -498,7 +498,7 @@ fn test_markdown_help() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     insta::assert_snapshot!("markdown-help", stdout);
     assert_eq!(stderr, "");
 }
@@ -771,7 +771,7 @@ fn test_unloaded() {
         .unwrap();
     let json_out = String::from_utf8(json_bytes).unwrap();
 
-    assert!(output.status.success());
+    assert!(output.status.success(), "{}", stderr);
     insta::assert_snapshot!("human-unloaded", stdout);
     insta::assert_snapshot!("json-pretty-unloaded", json_out);
     assert_eq!(stderr, "");

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 debugid = "0.8.0"
 encoding = "0.2"
-log = "0.4.1"
+tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.3"
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
 num-traits = "0.2"

--- a/minidump/src/context.rs
+++ b/minidump/src/context.rs
@@ -3,7 +3,6 @@
 
 //! CPU contexts.
 
-use log::warn;
 use num_traits::FromPrimitive;
 use scroll::{self, Pread};
 use std::collections::HashSet;
@@ -11,6 +10,7 @@ use std::fmt;
 use std::io;
 use std::io::prelude::*;
 use std::mem;
+use tracing::warn;
 
 use crate::iostuff::*;
 use crate::{MinidumpMiscInfo, MinidumpSystemInfo};

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -4,7 +4,6 @@
 use debugid::{CodeId, DebugId};
 use encoding::all::{UTF_16BE, UTF_16LE};
 use encoding::{DecoderTrap, Encoding};
-use log::warn;
 use memmap2::Mmap;
 use num_traits::FromPrimitive;
 use scroll::ctx::{SizeWith, TryFromCtx};
@@ -24,6 +23,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::str;
 use std::time::{Duration, SystemTime};
+use tracing::warn;
 use uuid::Uuid;
 
 pub use crate::context::*;


### PR DESCRIPTION
As a bonus(?) all the logs now use spans with field names. Some excerpts:

```
TRACE unwind{tid=771 name="MainThread"}: starting stack unwind of thread 771 MainThread
TRACE unwind{tid=771 name="MainThread"}: locating ("/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation", Some("ea76c90a23ed37918fbc8292916f0b16"), Some("CoreFoundation"), Some("ea76c90a-23ed-3791-8fbc-8292916f0b16"))
TRACE unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}:symbols{file="CoreFoundation"}: SimpleSymbolSupplier search
TRACE unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}: HttpSymbolSupplier search (SimpleSymbolSupplier found nothing)
TRACE unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}: HttpSymbolSupplier trying symbol server https://symbols.mozilla.org/
DEBUG unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}: Trying https://symbols.mozilla.org/CoreFoundation/EA76C90A23ED37918FBC8292916F0B160/CoreFoundation.sym?code_file=CoreFoundation&code_id=ea76c90a23ed37918fbc8292916f0b16
TRACE unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}: checkout waiting for idle connection: ("https", symbols.mozilla.org)
DEBUG unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}: starting new connection: https://symbols.mozilla.org/    
TRACE unwind{tid=771 name="MainThread"}:symbols{file="CoreFoundation"}: Http::connect; scheme=Some("https"), host=Some("symbols.mozilla.org"), port=None
DEBUG resolving host="symbols.mozilla.org"

....
```

```
TRACE unwind{tid=72455 name="ProcessHangMon"}: starting stack unwind of thread 72455 ProcessHangMon
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding __psynch_cvwait
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: found symbols for address, searching for cfi entries
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000188e52568, caller_sp: 0x0000000170ffe990
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding _pthread_cond_wait
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: found symbols for address, searching for cfi entries
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000102aefe68, caller_sp: 0x0000000170ffe9a0
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding 0x102aefe64
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: couldn't find symbols for address, cannot use cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000103a69668, caller_sp: 0x0000000170ffece0
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding 0x103a69664
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: couldn't find symbols for address, cannot use cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000103cfb0c0, caller_sp: 0x0000000170ffed90
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding 0x103cfb0bc
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: couldn't find symbols for address, cannot use cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000103cbbf28, caller_sp: 0x0000000170ffedc0
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding 0x103cbbf24
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: couldn't find symbols for address, cannot use cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000103a6122c, caller_sp: 0x0000000170ffef80
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding 0x103a61228
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: couldn't find symbols for address, cannot use cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x00000001034b8868, caller_sp: 0x0000000170ffefd0
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding 0x1034b8864
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: couldn't find symbols for address, cannot use cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000188e5206c, caller_sp: 0x0000000170ffeff0
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwinding _pthread_start
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying cfi
TRACE unwind{tid=72455 name="ProcessHangMon"}: unwind: found symbols for address, searching for cfi entries
TRACE unwind{tid=72455 name="ProcessHangMon"}: trying frame pointer
TRACE unwind{tid=72455 name="ProcessHangMon"}: frame pointer seems valid -- caller_pc: 0x0000000188e4cda0, caller_sp: 0x0000000170ffeff0
TRACE unwind{tid=72455 name="ProcessHangMon"}: stack pointer went backwards, assuming unwind complete
TRACE unwind{tid=72455 name="ProcessHangMon"}: finished stack unwind of thread 72455 ProcessHangMon
```