### PR TITLE
Remove inclusive ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
  "minidump-common",
  "minidump-synth",
  "num-traits 0.2.15",
- "range-map",
+ "rangemap",
  "scroll 0.11.0",
  "test-assembler",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "dump_syms",
  "minidump-common",
  "nom 1.2.4",
- "range-map",
+ "rangemap",
  "reqwest",
  "tempfile",
  "thiserror",
@@ -1388,6 +1388,12 @@ checksum = "87dc8ff3b0f3e32dbba6e49c592c0191a3a2cabbf6f7e5a78e1010050b9a42e1"
 dependencies = [
  "num-traits 0.1.43",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea2d559b3970fe7aa56ce7432a3702ff4b20a57b543ae08b4850ee629353ea6"
 
 [[package]]
 name = "redox_syscall"

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -29,7 +29,7 @@ dump_syms = { git = "https://github.com/mozilla/dump_syms", optional = true }
 tracing = { version = "0.1.34", features = ["log"] }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
 nom = "~1.2.2"
-range-map = "0.1.5"
+rangemap = "1"
 reqwest = { version = "0.11.6", default-features = false, features = [
     "gzip",
     "rustls-tls",

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -298,17 +298,17 @@ pub enum FileError {
 #[derive(Debug)]
 pub struct FillSymbolError {
     // We don't want to yield a full SymbolError for fill_symbol
-    // as this would involve cloning bulky Error strings every time
-    // someone requested symbols for a missing module.
-    //
-    // As it turns out there's currently no reason to care about *why*
-    // fill_symbol, so for now this is just a dummy type until we have
-    // something to put here.
-    //
-    // The only reason fill_symbol *can* produce an Err is so that
-    // the caller can distinguish between "we had symbols, but this address
-    // didn't map to a function name" and "we had no symbols for that module"
-    // (this is used as a heuristic for stack scanning).
+// as this would involve cloning bulky Error strings every time
+// someone requested symbols for a missing module.
+//
+// As it turns out there's currently no reason to care about *why*
+// fill_symbol, so for now this is just a dummy type until we have
+// something to put here.
+//
+// The only reason fill_symbol *can* produce an Err is so that
+// the caller can distinguish between "we had symbols, but this address
+// didn't map to a function name" and "we had no symbols for that module"
+// (this is used as a heuristic for stack scanning).
 }
 
 impl PartialEq for SymbolError {
@@ -895,10 +895,10 @@ mod test {
 
         let supplier = SimpleSymbolSupplier::new(paths.clone());
         let bad = SimpleModule::default();
-        assert_eq!(
-            supplier.locate_symbols(&bad).await,
-            Err(SymbolError::NotFound)
-        );
+        match supplier.locate_symbols(&bad).await {
+            Err(SymbolError::NotFound) => {}
+            _ => panic!(),
+        }
 
         // Try loading symbols for each of two modules in each of the two
         // search paths.
@@ -920,10 +920,10 @@ mod test {
         {
             let m = SimpleModule::new(file, id);
             // No symbols present yet.
-            assert_eq!(
-                supplier.locate_symbols(&m).await,
-                Err(SymbolError::NotFound)
-            );
+            match supplier.locate_symbols(&m).await {
+                Err(SymbolError::NotFound) => {}
+                _ => panic!(),
+            }
             write_good_symbol_file(&path.join(sym));
             // Should load OK now that it exists.
             assert!(
@@ -937,10 +937,10 @@ mod test {
         let debug_id = DebugId::from_str("ffff0000-0000-0000-0000-abcd12345678-a").unwrap();
         let mal = SimpleModule::new("baz.pdb", debug_id);
         let sym = "baz.pdb/FFFF0000000000000000ABCD12345678a/baz.sym";
-        assert_eq!(
-            supplier.locate_symbols(&mal).await,
-            Err(SymbolError::NotFound)
-        );
+        match supplier.locate_symbols(&mal).await {
+            Err(SymbolError::NotFound) => {}
+            _ => panic!(),
+        }
         write_bad_symbol_file(&paths[0].join(sym));
         let res = supplier.locate_symbols(&mal).await;
         assert!(

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.3"
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
 num-traits = "0.2"
-range-map = "0.1.5"
+rangemap = "1"
 scroll = "0.11.0"
 thiserror = "1.0.30"
 time = { version = "0.3.6", features = ["formatting"] }


### PR DESCRIPTION
Fixes #586.

This PR removes the dependency on range_map, which allows us to stop using inclusive ranges.

All of our ranges describe ranges of bytes in memory; for those, you basically always want half-open ranges of the form `start_address..end_address`.

To replace `range_map::RangeMap`, we use either sorted Vecs, or `rangemap::RangeMap`.
Note the missing underscore.

`rangemap::RangeMap` does not implement PartialEq / Eq, so some of the tests are changed from `assert_eq!` to a match statement.

It also does not support double-ended iterators.

For any RangeMaps which I converted to Vecs, I've changed the way we handle overlapping ranges, to do the following:

```
cur.lines.sort_by_key(|l| l.address);
cur.lines.dedup_by(|next, current| current.end_address() >= next.end_address());
```

This allows overlapping ranges if the next range sticks out from the end of its predecessor. And I've changed the tests to allow either value to be returned in the overlapping part.
Since overlapping ranges are usually a garbage input anyway, I'm hoping that this is an adequate way to deal with the situation. From what I gathered from the history of this code, the way we dealt with overlapping ranges was mostly aimed at avoiding panics from range_map, and not with the goal of any particular output.

There are two case where we care about the specific way we process overlapping ranges is this case, which I've preserved. The first one is about STACK WIN records:

https://github.com/rust-minidump/rust-minidump/blob/e0f8b5a7b4b6d9eebdf297f59c7aaa49c93f8494/breakpad-symbols/src/sym_file/parser.rs#L443-L474

And the second is about duplicated modules, and is handled in this breakpad code: https://chromium.googlesource.com/breakpad/breakpad/+/54fa71efbe50fb2b58096d871575b59e12edba6d/src/processor/minidump.cc#2784
I'm pretty sure I preserved that one too.

Overall, it's not the prettiest change, especially because I'm adding multiple manual calls to binary_search. But at least it's getting rid of a lot of occurrences of the pattern `end_address - 1`.