### PR TITLE
Various fixes & an attempt at stack scanning

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -1160,7 +1160,7 @@ impl Arm64RegisterNumbers {
 }
 
 /// MIPS floating point state
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Default, Clone, Pread, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FLOATING_SAVE_AREA_MIPS {
     pub regs: [u64; 32],
@@ -1171,7 +1171,7 @@ pub struct FLOATING_SAVE_AREA_MIPS {
 /// A MIPS CPU context
 ///
 /// This is a Breakpad extension, as there is no definition of `CONTEXT` for MIPS in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Default, Clone, Pread, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CONTEXT_MIPS {
     pub context_flags: u32,

--- a/minidump-processor/src/stackwalker/mips.rs
+++ b/minidump-processor/src/stackwalker/mips.rs
@@ -72,7 +72,7 @@ where
     if instruction_seems_valid(caller_ra, modules, symbol_provider).await {
         stack_walker
             .caller_ctx
-            .set_register(PROGRAM_COUNTER, caller_ra - 8);
+            .set_register(PROGRAM_COUNTER, caller_ra - 2 * POINTER_WIDTH);
     }
 
     trace!(
@@ -190,7 +190,7 @@ impl Unwind for MipsContext {
         // enforce progress and avoid infinite loops.
 
         let sp = frame.context.get_stack_pointer();
-        let last_sp = self.get_register_always("sp") as u64;
+        let last_sp = self.get_register_always(STACK_POINTER) as u64;
         if sp <= last_sp {
             // Arm leaf functions may not actually touch the stack (thanks
             // to the link register allowing you to "push" the return address

--- a/minidump-processor/src/stackwalker/mips.rs
+++ b/minidump-processor/src/stackwalker/mips.rs
@@ -76,9 +76,7 @@ where
     }
 
     trace!(
-        "unwind: cfi evaluation was successful -- caller_ra: 0x{:016x}, caller_sp: 0x{:016x}",
-        caller_ra,
-        caller_sp,
+        "unwind: cfi evaluation was successful -- caller_ra: {caller_ra:#016x}, caller_sp: {caller_sp:#016x}"
     );
 
     // Do absolutely NO validation! Yep! As long as CFI evaluation succeeds
@@ -169,9 +167,9 @@ impl Unwind for MipsContext {
             frame = get_caller_by_cfi(self, callee, grand_callee, stack, modules, syms).await;
         }
         // if we are at the context frame, we try to take the RA directly from the registers
-        if frame.is_none() && grand_callee.is_none() {
-            frame = get_caller_for_leaf(self, modules, syms).await;
-        }
+        // if frame.is_none() && grand_callee.is_none() {
+        //     frame = get_caller_for_leaf(self, modules, syms).await;
+        // }
         let mut frame = frame?;
 
         // We now check the frame to see if it looks like unwinding is complete,

--- a/minidump-processor/src/stackwalker/mips.rs
+++ b/minidump-processor/src/stackwalker/mips.rs
@@ -66,7 +66,7 @@ where
     symbol_provider
         .walk_frame(module, &mut stack_walker)
         .await?;
-    let caller_ra = stack_walker.caller_ctx.get_register_always(PROGRAM_COUNTER);
+    let caller_ra = stack_walker.caller_ctx.get_register_always(RETURN_ADDR);
     let caller_sp = stack_walker.caller_ctx.get_register_always(STACK_POINTER);
 
     if instruction_seems_valid(caller_ra, modules, symbol_provider).await {

--- a/minidump-processor/src/stackwalker/mips.rs
+++ b/minidump-processor/src/stackwalker/mips.rs
@@ -20,7 +20,7 @@ const STACK_POINTER: &str = "sp";
 const PROGRAM_COUNTER: &str = "pc";
 const RETURN_ADDR: &str = "ra";
 const CALLEE_SAVED_REGS: &[&str] = &[
-    "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28", "fp",
+    "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "gp", "sp", "fp",
 ];
 
 /*"$zero", "$at", "$v0", "$v1", "$a0", "$a1", "$a2", "$a3", "$to", "$t1",


### PR DESCRIPTION
I believe the `get_caller_for_leaf` function is unsound: it passes the stack pointer on unchanged to the caller. This is correct for leaf functions that don't use the stack at all, but for those that do, there's no way to recover the stack pointer in the absence of CFI.

I also attempted to replicate Breakpad's stackscanner for MIPS, but I'm not sure Breakpad even does remotely the right thing here. On other architectures you can stack scan because when you find a return address, you know that it was pushed on the stack just before the call to the current function. This lets you recover the stack pointer at the time of the call. But on MIPS, RA is saved on the stack in the caller's prologue, not just before the call, so finding a return address tells you nothing about the stack at the time of the call.