### PR TITLE
Add support for parsing INLINE_ORIGIN and INLINE.

### DIFF
--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -362,11 +362,11 @@ impl SymbolFile {
                 parameter_size,
             );
             // See if there's source line info as well.
-            func.lines.get(addr).map(|line| {
-                self.files.get(&line.file).map(|file| {
-                    frame.set_source_file(file, line.line, line.address + module.base_address());
-                })
-            });
+            if let Some((file_id, line, line_address)) = func.get_outermost_sourceloc(addr) {
+                if let Some(file) = self.files.get(&file_id) {
+                    frame.set_source_file(file, line, line_address + module.base_address());
+                }
+            }
         } else if let Some(public) = self.find_nearest_public(addr) {
             // We couldn't find a valid FUNC record, but we could find a PUBLIC record.
             // Unfortauntely, PUBLIC records don't have end-points, so this could be

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -3,10 +3,11 @@
 
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_while};
-use nom::character::complete::{char, hex_digit1, space1};
+use nom::character::complete::{hex_digit1, space1};
 use nom::character::{is_digit, is_hex_digit};
 use nom::combinator::{cut, map, map_res, opt};
 use nom::error::{Error, ErrorKind, ParseError};
+use nom::multi::separated_list1;
 use nom::sequence::{preceded, terminated, tuple};
 use nom::{Err, IResult};
 use range_map::{Range, RangeMap};
@@ -27,8 +28,9 @@ enum Line {
     Module,
     Info(Info),
     File(u32, String),
+    InlineOrigin(u32, String),
     Public(PublicSymbol),
-    Function(Function, Vec<SourceLine>),
+    Function(Function, Vec<SourceLine>, Vec<Inlinee>),
     StackWin(WinFrameType),
     StackCfi(StackInfoCfi),
 }
@@ -100,8 +102,8 @@ fn non_space(input: &[u8]) -> IResult<&[u8], &[u8]> {
 ///
 /// This is different from `line_ending` which doesn't accept `\r` if it isn't
 /// followed by `\n`.
-fn my_eol(input: &[u8]) -> IResult<&[u8], char> {
-    preceded(take_while(|b| b == b'\r'), char('\n'))(input)
+fn my_eol(input: &[u8]) -> IResult<&[u8], &[u8]> {
+    preceded(take_while(|b| b == b'\r'), tag(b"\n"))(input)
 }
 
 /// Accept everything except `\r` and `\n`.
@@ -157,6 +159,16 @@ fn file_line(input: &[u8]) -> IResult<&[u8], (u32, String)> {
         terminated(map_res(not_my_eol, str::from_utf8), my_eol),
     )))(input)?;
     Ok((input, (id, filename.to_string())))
+}
+
+// Matches an INLINE_ORIGIN record.
+fn inline_origin_line(input: &[u8]) -> IResult<&[u8], (u32, String)> {
+    let (input, _) = terminated(tag("INLINE_ORIGIN"), space1)(input)?;
+    let (input, (id, function)) = cut(tuple((
+        terminated(decimal_u32, space1),
+        terminated(map_res(not_my_eol, str::from_utf8), my_eol),
+    )))(input)?;
+    Ok((input, (id, function.to_string())))
 }
 
 // Matches a PUBLIC record.
@@ -215,7 +227,43 @@ fn func_line(input: &[u8]) -> IResult<&[u8], Function> {
             parameter_size,
             name: name.to_string(),
             lines: RangeMap::new(),
+            inlinees: Vec::new(),
         },
+    ))
+}
+
+// Matches one entry of the form <address> <size> which is used at the end of an INLINE record
+fn inline_address_range(input: &[u8]) -> IResult<&[u8], (u64, u32)> {
+    tuple((terminated(hex_str::<u64>, space1), hex_str::<u32>))(input)
+}
+
+// Matches an INLINE record.
+///
+/// An INLINE record has the form `INLINE <inline_nest_level> <call_site_line> <call_site_file_id> <origin_id> [<address> <size>]+`.
+fn inline_line(input: &[u8]) -> IResult<&[u8], impl Iterator<Item = Inlinee>> {
+    let (input, _) = terminated(tag("INLINE"), space1)(input)?;
+    let (input, (depth, call_line, call_file, origin_id)) = cut(tuple((
+        terminated(decimal_u32, space1),
+        terminated(decimal_u32, space1),
+        terminated(decimal_u32, space1),
+        terminated(decimal_u32, space1),
+    )))(input)?;
+    let (input, address_ranges) = cut(terminated(
+        separated_list1(space1, inline_address_range),
+        my_eol,
+    ))(input)?;
+    Ok((
+        input,
+        address_ranges
+            .into_iter()
+            .map(move |(address, size)| Inlinee {
+                address,
+                size,
+                call_file,
+                call_line,
+                depth,
+                origin_id,
+            }),
     ))
 }
 
@@ -340,8 +388,9 @@ fn line(input: &[u8]) -> IResult<&[u8], Line> {
         map(info_url, Line::Info),
         map(info_line, |_| Line::Info(Info::Unknown)),
         map(file_line, |(i, f)| Line::File(i, f)),
+        map(inline_origin_line, |(i, f)| Line::InlineOrigin(i, f)),
         map(public_line, Line::Public),
-        map(func_line, |f| Line::Function(f, Vec::new())),
+        map(func_line, |f| Line::Function(f, Vec::new(), Vec::new())),
         map(stack_win_line, Line::StackWin),
         map(stack_cfi_init, Line::StackCfi),
         map(module_line, |_| Line::Module),
@@ -358,6 +407,7 @@ fn line(input: &[u8]) -> IResult<&[u8], Line> {
 #[derive(Debug, Default)]
 pub struct SymbolParser {
     files: HashMap<u32, String>,
+    inline_origins: HashMap<u32, String>,
     publics: Vec<PublicSymbol>,
 
     // When building a RangeMap when need to sort an array of this
@@ -418,19 +468,20 @@ impl SymbolParser {
             // We `take` and then reconstitute the item for borrowing/move
             // reasons.
             match self.cur_item.take() {
-                Some(Line::Function(cur, mut lines)) => match func_line_data(input) {
-                    Ok((new_input, line)) => {
-                        lines.push(line);
-                        input = new_input;
-                        self.cur_item = Some(Line::Function(cur, lines));
-                        self.lines += 1;
-                        continue;
+                Some(Line::Function(cur, mut lines, mut inlinees)) => {
+                    match self.parse_func_subline(input, &mut lines, &mut inlinees) {
+                        Ok((new_input, ())) => {
+                            input = new_input;
+                            self.cur_item = Some(Line::Function(cur, lines, inlinees));
+                            self.lines += 1;
+                            continue;
+                        }
+                        Err(_) => {
+                            self.finish_item(Line::Function(cur, lines, inlinees));
+                            continue;
+                        }
                     }
-                    Err(_) => {
-                        self.finish_item(Line::Function(cur, lines));
-                        continue;
-                    }
-                },
+                }
                 Some(Line::StackCfi(mut cur)) => match stack_cfi(input) {
                     Ok((new_input, line)) => {
                         cur.add_rules.push(line);
@@ -483,6 +534,9 @@ impl SymbolParser {
                 }
                 Line::File(id, filename) => {
                     self.files.insert(id, filename.to_string());
+                }
+                Line::InlineOrigin(id, function) => {
+                    self.inline_origins.insert(id, function.to_string());
                 }
                 Line::Public(p) => {
                     self.publics.push(p);
@@ -542,7 +596,7 @@ impl SymbolParser {
                         _ => {}
                     }
                 }
-                item @ Line::Function(_, _) => {
+                item @ Line::Function(_, _, _) => {
                     // More sublines to parse
                     self.cur_item = Some(item);
                 }
@@ -557,25 +611,50 @@ impl SymbolParser {
         }
     }
 
+    /// Parses a single line which is following a FUNC line.
+    fn parse_func_subline<'a>(
+        &mut self,
+        input: &'a [u8],
+        lines: &mut Vec<SourceLine>,
+        inlinees: &mut Vec<Inlinee>,
+    ) -> IResult<&'a [u8], ()> {
+        // We can have three different types of sublines: INLINE_ORIGIN, INLINE, or line records.
+        // Check them one by one.
+        // We're not using nom's `alt()` here because we'd need to find a common return type.
+        if input.starts_with(b"INLINE_ORIGIN ") {
+            let (input, (id, function)) = inline_origin_line(input)?;
+            self.inline_origins.insert(id, function);
+            return Ok((input, ()));
+        }
+        if input.starts_with(b"INLINE ") {
+            let (input, new_inlinees) = inline_line(input)?;
+            inlinees.extend(new_inlinees);
+            return Ok((input, ()));
+        }
+        let (input, line) = func_line_data(input)?;
+        lines.push(line);
+        Ok((input, ()))
+    }
+
     /// Finish processing an item (cur_item) which had sublines.
     /// We now have all the sublines, so it's complete.
     fn finish_item(&mut self, item: Line) {
         match item {
-            Line::Function(mut cur, lines) => {
+            Line::Function(mut cur, lines, mut inlinees) => {
                 cur.lines = lines
                     .into_iter()
+                    // Line data from PDB files often has a zero-size line entry, so just
+                    // filter those out.
+                    .filter(|l| l.size > 0)
                     .map(|l| {
-                        // Line data from PDB files often has a zero-size line entry, so just
-                        // filter those out.
-                        if l.size > 0 {
-                            if let Some(end) = l.address.checked_add(l.size as u64 - 1) {
-                                return (Some(Range::new(l.address, end)), l);
-                            }
-                        }
-
-                        (None, l)
+                        let end_address = l.address.checked_add(l.size as u64 - 1);
+                        let range = end_address.map(|end| Range::new(l.address, end));
+                        (range, l)
                     })
                     .into_rangemap_safe();
+
+                inlinees.sort();
+                cur.inlinees = inlinees;
 
                 if let Some(range) = cur.memory_range() {
                     self.functions.push((range, cur));
@@ -761,6 +840,7 @@ fn test_func_lines_no_lines() {
                 name: "nsQueryInterfaceWithError::operator()(nsID const&, void**) const"
                     .to_string(),
                 lines: RangeMap::new(),
+                inlinees: Vec::new(),
             }
         ))
     );
@@ -779,10 +859,54 @@ fn test_truncated_func() {
 }
 
 #[test]
+fn test_inline_line_single_range() {
+    let line = b"INLINE 0 3082 52 1410 49200 10\n";
+    assert_eq!(
+        inline_line(line).unwrap().1.collect::<Vec<_>>(),
+        vec![Inlinee {
+            depth: 0,
+            address: 0x49200,
+            size: 0x10,
+            call_file: 52,
+            call_line: 3082,
+            origin_id: 1410
+        }]
+    )
+}
+
+#[test]
+fn test_inline_line_multiple_ranges() {
+    let line = b"INLINE 6 642 8 207 8b110 18 8b154 18\n";
+    assert_eq!(
+        inline_line(line).unwrap().1.collect::<Vec<_>>(),
+        vec![
+            Inlinee {
+                depth: 6,
+                address: 0x8b110,
+                size: 0x18,
+                call_file: 8,
+                call_line: 642,
+                origin_id: 207
+            },
+            Inlinee {
+                depth: 6,
+                address: 0x8b154,
+                size: 0x18,
+                call_file: 8,
+                call_line: 642,
+                origin_id: 207
+            }
+        ]
+    )
+}
+
+#[test]
 fn test_func_lines_and_lines() {
     let data = b"FUNC 1000 30 10 some func
 1000 10 42 7
+INLINE_ORIGIN 16 inlined_function_name()
 1010 10 52 8
+INLINE 0 23 9 16 1020 10
 1020 10 62 15
 ";
     let file = SymbolFile::from_bytes(data).expect("failed to parse!");
@@ -832,6 +956,104 @@ fn test_func_lines_and_lines() {
             ),
         ]
     );
+    assert_eq!(
+        f.inlinees,
+        vec![Inlinee {
+            depth: 0,
+            address: 0x1020,
+            size: 0x10,
+            call_file: 9,
+            call_line: 23,
+            origin_id: 16
+        }]
+    );
+}
+
+#[test]
+fn test_nested_inlines() {
+    // 0x1000: outer_func() @ <file 15>:60 -> mid_func() @ <file 4>:12 -> inner_func1() <file 7>:42
+    // 0x1010: outer_func() @ <file 15>:60 -> mid_func() @ <file 4>:17 -> inner_func2() <file 8>:52
+    // 0x1020: outer_func() @ <file 15>:62
+    let data = b"FUNC 1000 30 10 outer_func()
+INLINE_ORIGIN 1 inner_func_2()
+INLINE_ORIGIN 2 mid_func()
+INLINE_ORIGIN 3 inner_func_1()
+INLINE 0 60 15 2 1000 20
+INLINE 1 12 4 3 1000 10
+INLINE 1 17 4 1 1010 10
+1000 10 42 7
+1010 10 52 8
+1020 10 62 15
+";
+    let file = SymbolFile::from_bytes(data).expect("failed to parse!");
+    let (_, f) = file.functions.ranges_values().next().unwrap();
+    assert_eq!(f.address, 0x1000);
+    assert_eq!(f.size, 0x30);
+    assert_eq!(f.parameter_size, 0x10);
+    assert_eq!(f.name, "outer_func()".to_string());
+
+    // Check the source locations at the "outermost" level, i.e. the line
+    // numbers inside the "outer_func()" function. This function has its
+    // code in file 15, so all source locations at this level should be
+    // in that file.
+    assert_eq!(f.get_outermost_sourceloc(0x0fff), None);
+    assert_eq!(f.get_outermost_sourceloc(0x1000), Some((15, 60, 0x1000)));
+    assert_eq!(f.get_outermost_sourceloc(0x100f), Some((15, 60, 0x1000)));
+    assert_eq!(f.get_outermost_sourceloc(0x1010), Some((15, 60, 0x1000)));
+    assert_eq!(f.get_outermost_sourceloc(0x101f), Some((15, 60, 0x1000)));
+    assert_eq!(f.get_outermost_sourceloc(0x1020), Some((15, 62, 0x1020)));
+    assert_eq!(f.get_outermost_sourceloc(0x102f), Some((15, 62, 0x1020)));
+    assert_eq!(f.get_outermost_sourceloc(0x1030), None);
+
+    // Check the first level of inlining. There is only one inlined call
+    // at this level, the call from outer_func() to mid_func(), spanning
+    // the range 0x1000..0x1020.
+    assert_eq!(f.get_inlinee_at_depth(0, 0x0fff), None);
+    assert_eq!(f.get_inlinee_at_depth(0, 0x1000), Some((15, 60, 0x1000, 2)));
+    assert_eq!(f.get_inlinee_at_depth(0, 0x100f), Some((15, 60, 0x1000, 2)));
+    assert_eq!(f.get_inlinee_at_depth(0, 0x1010), Some((15, 60, 0x1000, 2)));
+    assert_eq!(f.get_inlinee_at_depth(0, 0x101f), Some((15, 60, 0x1000, 2)));
+    assert_eq!(f.get_inlinee_at_depth(0, 0x1020), None);
+    assert_eq!(f.get_inlinee_at_depth(0, 0x102f), None);
+    assert_eq!(f.get_inlinee_at_depth(0, 0x1030), None);
+
+    // Check the second level of inlining. Two function calls from mid_func()
+    // have been inlined at this level, the call to inner_func_1() and the
+    // call to inner_func_2().
+    // The code for mid_func() is in file 4, so the location of the calls to
+    // inner_func_1() and inner_func_2() are in file 4.
+    assert_eq!(f.get_inlinee_at_depth(1, 0x0fff), None);
+    assert_eq!(f.get_inlinee_at_depth(1, 0x1000), Some((4, 12, 0x1000, 3)));
+    assert_eq!(f.get_inlinee_at_depth(1, 0x100f), Some((4, 12, 0x1000, 3)));
+    assert_eq!(f.get_inlinee_at_depth(1, 0x1010), Some((4, 17, 0x1010, 1)));
+    assert_eq!(f.get_inlinee_at_depth(1, 0x101f), Some((4, 17, 0x1010, 1)));
+    assert_eq!(f.get_inlinee_at_depth(1, 0x1020), None);
+    assert_eq!(f.get_inlinee_at_depth(1, 0x102f), None);
+    assert_eq!(f.get_inlinee_at_depth(1, 0x1030), None);
+
+    // Check that there are no deeper inline calls.
+    assert_eq!(f.get_inlinee_at_depth(2, 0x0fff), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x1000), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x100f), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x1010), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x101f), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x1020), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x102f), None);
+    assert_eq!(f.get_inlinee_at_depth(2, 0x1030), None);
+
+    // Check the "innermost" source locations. These locations describe the
+    // file and line at the deepest level of inlining at the given address.
+    // We have a location in inner_func_1() (whose code is in file 7), a location
+    // in inner_func_2() (whose code is in file 8), and a location in the outer
+    // function outer_func() (whose code is in file 15).
+    assert_eq!(f.get_innermost_sourceloc(0x0fff), None);
+    assert_eq!(f.get_innermost_sourceloc(0x1000), Some((7, 42, 0x1000)));
+    assert_eq!(f.get_innermost_sourceloc(0x100f), Some((7, 42, 0x1000)));
+    assert_eq!(f.get_innermost_sourceloc(0x1010), Some((8, 52, 0x1010)));
+    assert_eq!(f.get_innermost_sourceloc(0x101f), Some((8, 52, 0x1010)));
+    assert_eq!(f.get_innermost_sourceloc(0x1020), Some((15, 62, 0x1020)));
+    assert_eq!(f.get_innermost_sourceloc(0x102f), Some((15, 62, 0x1020)));
+    assert_eq!(f.get_innermost_sourceloc(0x1030), None);
 }
 
 #[test]

--- a/breakpad-symbols/src/sym_file/types.rs
+++ b/breakpad-symbols/src/sym_file/types.rs
@@ -33,6 +33,25 @@ pub struct SourceLine {
     pub line: u32,
 }
 
+/// A single range which is covered by an inlined function call.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Inlinee {
+    /// The depth of the inline call.
+    pub depth: u32,
+    /// The start address relative to the module's load address.
+    pub address: u64,
+    /// The size of this range of instructions in bytes.
+    pub size: u32,
+    /// The source file which contains the function call.
+    ///
+    /// This is an index into `SymbolFile::files`.
+    pub call_file: u32,
+    /// The line number in `call_file` for the function call.
+    pub call_line: u32,
+    /// The function name, as an index into `SymbolFile::inline_origins`.
+    pub origin_id: u32,
+}
+
 /// A source-language function.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Function {
@@ -46,6 +65,13 @@ pub struct Function {
     pub name: String,
     /// Source line information for this function.
     pub lines: RangeMap<u64, SourceLine>,
+    /// Inlinee information for this function, sorted by (depth, address).
+    ///
+    /// Essentially this can be considered as "one vec per depth", just with
+    /// all those vecs concatenated into one.
+    ///
+    /// Inlinees form a nested structure, you can think of them like a flame graph.
+    pub inlinees: Vec<Inlinee>,
 }
 
 impl Function {
@@ -57,6 +83,69 @@ impl Function {
             self.address,
             self.address.checked_add(self.size as u64)? - 1,
         ))
+    }
+
+    /// Returns `(file_id, line, address)` of the line or inline record that
+    /// covers the given address at inlining level zero, i.e. at the level of
+    /// the outer function, outside any inlined calls.
+    pub fn get_outermost_sourceloc(&self, addr: u64) -> Option<(u32, u32, u64)> {
+        // If there is an inlined call at depth 0 covering this address, then
+        // we want to return the source location of that call.
+        if let Some((call_file, call_line, address, _)) = self.get_inlinee_at_depth(0, addr) {
+            return Some((call_file, call_line, address));
+        }
+        // Otherwise we return the line record covering this address.
+        let line = self.lines.get(addr)?;
+        Some((line.file, line.line, line.address))
+    }
+
+    /// Returns `(file_id, line, address)` of the line record that covers the
+    /// given address. Line records describe locations at the deepest level of
+    /// inlining at that address.
+    ///
+    /// For example, if we have an "inline call stack" A -> B -> C at this
+    /// address, i.e. both the call to B and the call to C have been inlined all
+    /// the way into A (A being the "outer function"), then this method reports
+    /// locations in C.
+    pub fn get_innermost_sourceloc(&self, addr: u64) -> Option<(u32, u32, u64)> {
+        let line = self.lines.get(addr)?;
+        Some((line.file, line.line, line.address))
+    }
+
+    /// Returns `(call_file_id, call_line, address, inline_origin)` of the
+    /// inlinee record that covers the given address at the given depth.
+    ///
+    /// We start at depth zero. For example, if we have an "inline call stack"
+    /// A -> B -> C at an address, i.e. both the call to B and the call to C have
+    /// been inlined all the way into A (A being the "outer function"), then the
+    /// call A -> B is at level zero, and the call B -> C is at level one.
+    pub fn get_inlinee_at_depth(&self, depth: u32, addr: u64) -> Option<(u32, u32, u64, u32)> {
+        let inlinee = match self
+            .inlinees
+            .binary_search_by_key(&(depth, addr), |inlinee| (inlinee.depth, inlinee.address))
+        {
+            // Exact match
+            Ok(index) => &self.inlinees[index],
+            // No match, insertion index is zero => before first element
+            Err(0) => return None,
+            // No exact match, insertion index points after inlinee whose (depth, addr) is < what were looking for
+            // => subtract 1 to get candidate
+            Err(index) => &self.inlinees[index - 1],
+        };
+        if inlinee.depth != depth {
+            return None;
+        }
+        let end_address = inlinee.address.checked_add(inlinee.size as u64)?;
+        if addr < end_address {
+            Some((
+                inlinee.call_file,
+                inlinee.call_line,
+                inlinee.address,
+                inlinee.origin_id,
+            ))
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
This parses the new format but produces the same output as before.
So with this patch alone, we will not get any inline information in the
output.
But this patch allows us to switch to the new sym format without
breaking anything (hopefully).

In `fill_symbol` we now call `get_outermost_source_location`, which has
to look at the inline information, because just by looking at the lines
you would not get the same output as before with the new sym files.
That's because, when inline information is present in sym files, the
line records now describe the lines *at the deepest level of inlining*.
In sym files without inline information, the line records describe the
lines at the outermost level.