### PR TITLE
[proof of concept] concurrent stackwalking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ dependencies = [
  "breakpad-symbols",
  "debugid 0.8.0",
  "doc-comment",
+ "futures-util",
  "memmap2",
  "minidump",
  "minidump-common",

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -644,7 +644,7 @@ fn into_rangemap_safe<V: Clone + Eq + Debug>(mut input: Vec<(Range<u64>, V)>) ->
 
 #[cfg(test)]
 fn parse_symbol_bytes(data: &[u8]) -> Result<SymbolFile, SymbolError> {
-    SymbolFile::parse(data, |_| ())
+    SymbolFile::from_bytes(data)
 }
 
 #[test]

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -37,6 +37,7 @@ scroll = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.30"
+futures-util = "0.3.21"
 
 [dev-dependencies]
 doc-comment = "0.3.3"


### PR DESCRIPTION
This is a proof-of-concept for:

1. making breakpad-symbols more properly async by reworking the streaming parser to be more stateful and not in charge of the http Response and only* using tokio::fs.
2. making minidump-processor `join` all the stackwalks

Commit 1 is the bulk of the work, Commit 2 is just a quick and dirty hack.

The net result is that all stackwalking is now concurrent, but not parallel. hot stackwalks take about the same amount of time, because file i/o is ultimately blocking, while cold (http) stackwalks on firefox take about half the time from being able to download things in parallel.

Subsequent comments will include some notes/numbers.