### PR TITLE
Emit inlines in the minidump JSON

### DIFF
--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -452,6 +452,9 @@ pub trait FrameSymbolizer {
     fn set_function(&mut self, name: &str, base: u64, parameter_size: u32);
     /// Set the source file and (1-based) line number this frame represents.
     fn set_source_file(&mut self, file: &str, line: u32, base: u64);
+    /// Add an inline frame. This method can be called multiple times, in the
+    /// order "outside to inside".
+    fn add_inline_frame(&mut self, _name: &str, _file: Option<&str>, _line: Option<u32>) {}
 }
 
 pub trait FrameWalker {

--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -362,11 +362,11 @@ impl SymbolFile {
                 parameter_size,
             );
             // See if there's source line info as well.
-            func.lines.get(addr).map(|line| {
-                self.files.get(&line.file).map(|file| {
-                    frame.set_source_file(file, line.line, line.address + module.base_address());
-                })
-            });
+            if let Some((file_id, line, line_address)) = func.get_outermost_source_location(addr) {
+                if let Some(file) = self.files.get(&file_id) {
+                    frame.set_source_file(file, line, line_address + module.base_address());
+                }
+            }
         } else if let Some(public) = self.find_nearest_public(addr) {
             // We couldn't find a valid FUNC record, but we could find a PUBLIC record.
             // Unfortauntely, PUBLIC records don't have end-points, so this could be

--- a/breakpad-symbols/src/sym_file/parser.rs
+++ b/breakpad-symbols/src/sym_file/parser.rs
@@ -688,6 +688,7 @@ impl SymbolParser {
             files: self.files,
             publics: self.publics,
             functions: into_rangemap_safe(self.functions),
+            inline_origins: self.inline_origins,
             cfi_stack_info: into_rangemap_safe(self.cfi_stack_info),
             win_stack_framedata_info: into_rangemap_safe(self.win_stack_framedata_info),
             win_stack_fpo_info: into_rangemap_safe(self.win_stack_fpo_info),

--- a/breakpad-symbols/src/sym_file/types.rs
+++ b/breakpad-symbols/src/sym_file/types.rs
@@ -80,15 +80,15 @@ impl Function {
         ))
     }
 
-    /// Returns `(file_id, line, address)` of the line or inline record that
+    /// Returns `(file_id, line, address, inline_origin)` of the line or inline record that
     /// covers the given address at the outermost level (i.e. not inside any
     /// inlined calls).
-    pub fn get_outermost_source_location(&self, addr: u64) -> Option<(u32, u32, u64)> {
-        if let Some((call_file, call_line, address, _)) = self.get_inlinee_at_depth(0, addr) {
-            return Some((call_file, call_line, address));
+    pub fn get_outermost_source_location(&self, addr: u64) -> Option<(u32, u32, u64, Option<u32>)> {
+        if let Some((call_file, call_line, address, origin)) = self.get_inlinee_at_depth(0, addr) {
+            return Some((call_file, call_line, address, Some(origin)));
         }
         let line = self.lines.get(addr)?;
-        Some((line.file, line.line, line.address))
+        Some((line.file, line.line, line.address, None))
     }
 
     /// Returns `(file_id, line, address)` of the line record that covers the
@@ -236,6 +236,8 @@ pub struct SymbolFile {
     pub publics: Vec<PublicSymbol>,
     /// Functions.
     pub functions: RangeMap<u64, Function>,
+    /// Function names for inlined functions.
+    pub inline_origins: HashMap<u32, String>,
     /// DWARF CFI unwind information.
     pub cfi_stack_info: RangeMap<u64, StackInfoCfi>,
     /// Windows unwind information (frame data).

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -63,6 +63,17 @@ pub struct FunctionArg {
     pub value: Option<u64>,
 }
 
+/// A stack frame in an inlined function.
+#[derive(Debug)]
+pub struct InlineFrame {
+    /// The name of the function
+    pub function_name: String,
+    /// The file name of the stack frame
+    pub source_file_name: Option<String>,
+    /// The line number of the stack frame
+    pub source_line: Option<u32>,
+}
+
 /// A single stack frame produced from unwinding a thread's stack.
 #[derive(Debug)]
 pub struct StackFrame {
@@ -156,6 +167,9 @@ pub struct StackFrame {
     /// The start address of the source line, may be omitted if debug symbols
     /// are not available.
     pub source_line_base: Option<u64>,
+
+    /// Any inline frames that cover the frame address, ordered from outside to inside.
+    pub inlines: Vec<InlineFrame>,
 
     /// Amount of trust the stack walker has in the instruction pointer
     /// of this frame.
@@ -304,6 +318,7 @@ impl StackFrame {
             source_file_name: None,
             source_line: None,
             source_line_base: None,
+            inlines: Vec::new(),
             arguments: None,
             trust,
             context,
@@ -324,6 +339,16 @@ impl FrameSymbolizer for StackFrame {
         self.source_file_name = Some(String::from(file));
         self.source_line = Some(line);
         self.source_line_base = Some(base);
+    }
+    /// This function can be called multiple times, for the inlines that cover the
+    /// address at various levels of inlining. The call order is from outside to
+    /// inside.
+    fn add_inline_frame(&mut self, name: &str, file: Option<&str>, line: Option<u32>) {
+        self.inlines.push(InlineFrame {
+            function_name: name.to_string(),
+            source_file_name: file.map(ToString::to_string),
+            source_line: line,
+        })
     }
 }
 
@@ -393,6 +418,7 @@ impl CallStack {
     ///
     /// This is very verbose, it implements the output format used by
     /// minidump_stackwalk.
+    /// This currently does not output inline frames.
     pub fn print<T: Write>(&self, f: &mut T) -> io::Result<()> {
         if self.frames.is_empty() {
             writeln!(f, "<no frames>")?;
@@ -840,6 +866,21 @@ Unknown streams encountered:
                     // optional
                     "line": frame.source_line,
                     "offset": json_hex(frame.instruction),
+                    // optional
+                    "inlines": if !frame.inlines.is_empty() {
+                        // In the JSON, inline frames are ordered from inside to outside.
+                        // In frame.inlines, they are ordered from outside to inside.
+                        // So we need to reverse the order here.
+                        Some(frame.inlines.iter().rev().map(|frame| {
+                            json!({
+                                "function": frame.function_name,
+                                "file": frame.source_file_name,
+                                "line": frame.source_line,
+                            })
+                        }).collect::<Vec<_>>())
+                    } else {
+                        None
+                    },
                     // optional
                     "module_offset": frame
                         .module


### PR DESCRIPTION
This adds an `inlines` field to the JSON for every stack frame which has at least one inlined call at the stack frame address. Each element in the `inlines` array has the properties `function`, `file`, and `line`, with the latter two being optional. The inlines are ordered from inside to outside.

This format matches what I originally proposed it in [this bugzilla comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1636194#c6) for the [Tecken / symbolication API](https://tecken.readthedocs.io/en/latest/symbolication.html). That's a different API, but its response JSON format was influenced by the minidump JSON format.

The implementation of the symbolication API in [profiler-get-symbols](https://github.com/mstange/profiler-get-symbols) is already using that format - it is used when profiling local Firefox builds or when using [profiler-symbol-server](https://github.com/mstange/profiler-symbol-server/) to resymbolicate profiles.

[Here is an example minidump JSON](https://gist.github.com/mstange/55648469006e25fd24285af9cea0e03a) where I manually replaced the XUL.sym file in the symbol cache with a XUL.sym containing inlines, which I generated from the corresponding XUL.dSYM with a local dump_syms which includes the work from https://github.com/mozilla/dump_syms/pull/392. (Note that example minidump JSON contains file paths of the form `/builds/worker/workspace/...`; this is only because that's what's in the dSYM. Ignore that difference.)

This PR is WIP because it's missing tests and documentation.