### PR TITLE
bump the apple ptr-auth real bits to 47

### DIFF
--- a/minidump-processor/src/stackwalker/arm64.rs
+++ b/minidump-processor/src/stackwalker/arm64.rs
@@ -273,8 +273,8 @@ fn ptr_auth_strip(modules: &MinidumpModuleList, ptr: Pointer) -> Pointer {
     //
     // To help us guess, we have a few pieces of information:
     //
-    // * Apple seems to default to a 24/40 split, so 40 bits for the "real" is a good baseline
-    // * We know the address ranges of various loaded/unloaded modules
+    // * Apple seems to default to a 17/47 split, so 47 bits for "real" is a good baseline
+    // * We know the address ranges of various loaded (and unloaded modules)
     // * We know the address range of the stacks
     // * We *can* know the address range of some sections of the heap (MemoryList)
     // * We *can* know the page mappings (MemoryInfo)
@@ -282,7 +282,7 @@ fn ptr_auth_strip(modules: &MinidumpModuleList, ptr: Pointer) -> Pointer {
     // Right now we only incorporate the first two. Ideally we would process all those sources
     // once at the start of stack walking and pass it down to the ARM stackwalker but that's
     // a lot of annoying rewiring that won't necessarily improve results.
-    let apple_default_max_addr = (1 << 40) - 1;
+    let apple_default_max_addr = (1 << 47) - 1;
     let max_module_addr = modules
         .by_addr()
         .next_back()

--- a/minidump-processor/src/stackwalker/arm64_old.rs
+++ b/minidump-processor/src/stackwalker/arm64_old.rs
@@ -273,8 +273,8 @@ fn ptr_auth_strip(modules: &MinidumpModuleList, ptr: Pointer) -> Pointer {
     //
     // To help us guess, we have a few pieces of information:
     //
-    // * Apple seems to default to a 24/40 split, so 40 bits for the "real" is a good baseline
-    // * We know the address ranges of various loaded/unloaded modules
+    // * Apple seems to default to a 17/47 split, so 47 bits for "real" is a good baseline
+    // * We know the address ranges of various loaded (and unloaded modules)
     // * We know the address range of the stacks
     // * We *can* know the address range of some sections of the heap (MemoryList)
     // * We *can* know the page mappings (MemoryInfo)
@@ -282,7 +282,7 @@ fn ptr_auth_strip(modules: &MinidumpModuleList, ptr: Pointer) -> Pointer {
     // Right now we only incorporate the first two. Ideally we would process all those sources
     // once at the start of stack walking and pass it down to the ARM stackwalker but that's
     // a lot of annoying rewiring that won't necessarily improve results.
-    let apple_default_max_addr = (1 << 40) - 1;
+    let apple_default_max_addr = (1 << 47) - 1;
     let max_module_addr = modules
         .by_addr()
         .next_back()

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -627,7 +627,7 @@ async fn test_frame_pointer_ptr_auth_strip() {
 
     let return_address1 = 0x50000100u64;
     let return_address2 = 0x50000900u64;
-    let authenticated_return_address1 = return_address1 | 0x0013_4300_0000_0000;
+    let authenticated_return_address1 = return_address1 | 0x0013_8000_0000_0000;
     let authenticated_return_address2 = return_address2 | 0x1110_0000_0000_0000;
 
     let frame1_sp = Label::new();
@@ -664,7 +664,7 @@ async fn test_frame_pointer_ptr_auth_strip() {
         .D64(0);
 
     authenticated_frame1_fp.set_const(frame1_fp.value().unwrap() | 0xa310_0000_0000_0000);
-    authenticated_frame2_fp.set_const(frame2_fp.value().unwrap() | 0xf31e_0700_0000_0000);
+    authenticated_frame2_fp.set_const(frame2_fp.value().unwrap() | 0xf31e_8000_0000_0000);
 
     f.raw.set_register("pc", 0x40005510);
     f.raw.set_register("lr", 0x1fe0fe10);
@@ -996,8 +996,8 @@ async fn test_cfi_at_4005_ptr_auth_strip_apple() {
         .D64(0xdd5a48c848c8dd5a) // saved x1 (even though it's not callee-saves)
         .D64(0xff3dfb81fb81ff3d) // no longer saved x19
         .D64(0x34f3ebd1ebd134f3) // no longer saved x20
-        .D64(0xae23_45a2_8112_e110) // saved fp WITH AUTH
-        .D64(0xae1d_f700_4000_5510) // return address WITH AUTH
+        .D64(0xae23_80a2_8112_e110) // saved fp WITH AUTH
+        .D64(0xae1d_0000_4000_5510) // return address WITH AUTH
         .mark(&frame1_sp)
         .append_repeated(0, 120);
 


### PR DESCRIPTION
The proper value for a system can be found with

```
% sysctl machdep.virtual_address_size
```

Which on the machine mstange tested yields 47. We were seeing 40 being too low in practice
for JIT code pages. Ideally this is information that the minidump_writer should stuff somewhere
so that we can precisely do this. Apparently crashpad already does this somewhere but I lost
track of that message.