### PR TITLE
ref: Remove unused symbolic-shim

### DIFF
--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -13,11 +13,7 @@ edition = "2018"
 travis-ci = { repository = "rust-minidump/rust-minidump" }
 
 [features]
-default = ["breakpad-syms"]
-# Use the `breakpad-symbols` crate for symbolizing and cfi evaluation
-breakpad-syms = ["breakpad-symbols"]
-# Use the `symbolic` crate for symbolizing and cfi evaluation (TODO)
-symbolic-syms = []
+default = []
 # Allows retrieval of symbol files via HTTP
 http = ["breakpad-symbols/http"]
 # Allows construction of symbol files from native binaries
@@ -27,7 +23,7 @@ mozilla_cab_symbols = ["breakpad-symbols/mozilla_cab_symbols"]
 
 [dependencies]
 async-trait = "0.1.51"
-breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols", optional = true }
+breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols" }
 debugid = "0.8.0"
 tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.3"

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -1,12 +1,5 @@
 //! This module defines the interface between minidump-processor and its [Symbolizer][].
 //!
-//! There can only be one [Symbolizer][], and this is configured by minidump-processor's Cargo
-//! feature flags. The currently defined Symbolizers are:
-//!
-//! * breakpad_symbols -- feature: breakpad-syms (currently the default)
-//! * symbolic -- feature: symbolic-syms (not yet implemented, but compiles)
-//!
-//!
 //! minidump-processor and the [Symbolizer][] communicate using a series of traits. The symbolizer
 //! must provide implementations of these traits:
 //!

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -96,10 +96,16 @@
 //! ```
 //!
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use minidump::Module;
-use std::{collections::HashMap, path::PathBuf};
-pub use symbols_shim::*;
+
+pub use breakpad_symbols::{
+    FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolError, SymbolFile,
+    SymbolStats, SymbolSupplier, Symbolizer,
+};
 
 #[async_trait]
 pub trait SymbolProvider {
@@ -193,385 +199,84 @@ impl SymbolProvider for MultiSymbolProvider {
     }
 }
 
-#[cfg(feature = "breakpad-syms")]
-mod symbols_shim {
-    use super::SymbolProvider;
-    use async_trait::async_trait;
-    pub use breakpad_symbols::{
-        FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolError,
-        SymbolFile, SymbolStats, SymbolSupplier, Symbolizer,
-    };
-    use minidump::Module;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-
-    #[async_trait]
-    impl SymbolProvider for Symbolizer {
-        async fn fill_symbol(
-            &self,
-            module: &(dyn Module + Sync),
-            frame: &mut (dyn FrameSymbolizer + Send),
-        ) -> Result<(), FillSymbolError> {
-            self.fill_symbol(module, frame).await
-        }
-        async fn walk_frame(
-            &self,
-            module: &(dyn Module + Sync),
-            walker: &mut (dyn FrameWalker + Send),
-        ) -> Option<()> {
-            self.walk_frame(module, walker).await
-        }
-        async fn get_file_path(
-            &self,
-            module: &(dyn Module + Sync),
-            file_kind: FileKind,
-        ) -> Result<PathBuf, FileError> {
-            self.get_file_path(module, file_kind).await
-        }
-        fn stats(&self) -> HashMap<String, SymbolStats> {
-            self.stats()
-        }
+#[async_trait]
+impl SymbolProvider for Symbolizer {
+    async fn fill_symbol(
+        &self,
+        module: &(dyn Module + Sync),
+        frame: &mut (dyn FrameSymbolizer + Send),
+    ) -> Result<(), FillSymbolError> {
+        self.fill_symbol(module, frame).await
     }
-
-    /// Gets a SymbolSupplier that looks up symbols by path or with urls.
-    ///
-    /// * `symbols_paths` is a list of paths to check for symbol files. Paths
-    ///   are searched in order until one returns a payload. If none do, then
-    ///   urls are used.
-    ///
-    /// * `symbols_urls` is a list of "base urls" that should all point to Tecken
-    ///   servers. urls are queried in order until one returns a payload. If none
-    ///   do, then it's an error.
-    ///
-    /// * `symbols_cache` is a directory where an on-disk cache should be located.
-    ///   This should be assumed to be a "temp" directory that another process
-    ///   you don't control is garbage-collecting old files from (to provide an LRU cache).
-    ///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
-    ///
-    /// * `symbols_tmp` is a directory where symbol files should be downloaded to
-    ///   before atomically swapping them into the cache. Has the same "temp"
-    ///   assumptions as symbols_cache.
-    ///
-    /// * `timeout` a maximum time limit for a symbol file download. This
-    ///   is primarily defined to avoid getting stuck on buggy infinite downloads.
-    ///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
-    ///   the event of a timeout, the supplier may still try to parse the truncated
-    ///   download.
-    #[cfg(feature = "http")]
-    pub fn http_symbol_supplier(
-        symbol_paths: Vec<PathBuf>,
-        symbol_urls: Vec<String>,
-        symbols_cache: PathBuf,
-        symbols_tmp: PathBuf,
-        timeout: std::time::Duration,
-    ) -> impl SymbolSupplier {
-        breakpad_symbols::HttpSymbolSupplier::new(
-            symbol_urls,
-            symbols_cache,
-            symbols_tmp,
-            symbol_paths,
-            timeout,
-        )
+    async fn walk_frame(
+        &self,
+        module: &(dyn Module + Sync),
+        walker: &mut (dyn FrameWalker + Send),
+    ) -> Option<()> {
+        self.walk_frame(module, walker).await
     }
-
-    /// Gets a SymbolSupplier that looks up symbols by path.
-    ///
-    /// Paths are queried in order until one returns a payload.
-    pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
-        breakpad_symbols::SimpleSymbolSupplier::new(symbol_paths)
+    async fn get_file_path(
+        &self,
+        module: &(dyn Module + Sync),
+        file_kind: FileKind,
+    ) -> Result<PathBuf, FileError> {
+        self.get_file_path(module, file_kind).await
     }
-
-    /// Gets a mock SymbolSupplier that just maps module names
-    /// to a string containing an entire breakpad .sym file, for tests.
-    pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
-        breakpad_symbols::StringSymbolSupplier::new(modules)
+    fn stats(&self) -> HashMap<String, SymbolStats> {
+        self.stats()
     }
 }
 
-#[cfg(all(feature = "symbolic-syms", not(feature = "breakpad-syms")))]
-mod symbols_shim {
-    #![allow(dead_code)]
+/// Gets a SymbolSupplier that looks up symbols by path or with urls.
+///
+/// * `symbols_paths` is a list of paths to check for symbol files. Paths
+///   are searched in order until one returns a payload. If none do, then
+///   urls are used.
+///
+/// * `symbols_urls` is a list of "base urls" that should all point to Tecken
+///   servers. urls are queried in order until one returns a payload. If none
+///   do, then it's an error.
+///
+/// * `symbols_cache` is a directory where an on-disk cache should be located.
+///   This should be assumed to be a "temp" directory that another process
+///   you don't control is garbage-collecting old files from (to provide an LRU cache).
+///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
+///
+/// * `symbols_tmp` is a directory where symbol files should be downloaded to
+///   before atomically swapping them into the cache. Has the same "temp"
+///   assumptions as symbols_cache.
+///
+/// * `timeout` a maximum time limit for a symbol file download. This
+///   is primarily defined to avoid getting stuck on buggy infinite downloads.
+///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
+///   the event of a timeout, the supplier may still try to parse the truncated
+///   download.
+#[cfg(feature = "http")]
+pub fn http_symbol_supplier(
+    symbol_paths: Vec<PathBuf>,
+    symbol_urls: Vec<String>,
+    symbols_cache: PathBuf,
+    symbols_tmp: PathBuf,
+    timeout: std::time::Duration,
+) -> impl SymbolSupplier {
+    breakpad_symbols::HttpSymbolSupplier::new(
+        symbol_urls,
+        symbols_cache,
+        symbols_tmp,
+        symbol_paths,
+        timeout,
+    )
+}
 
-    use super::SymbolProvider;
-    use async_trait::async_trait;
-    use minidump::Module;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-    use std::time::Duration;
+/// Gets a SymbolSupplier that looks up symbols by path.
+///
+/// Paths are queried in order until one returns a payload.
+pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
+    breakpad_symbols::SimpleSymbolSupplier::new(symbol_paths)
+}
 
-    // Import symbolic here
-
-    /// A trait for things that can locate symbols for a given module.
-    #[async_trait]
-    pub trait SymbolSupplier {
-        /// Locate and load a symbol file for `module`.
-        ///
-        /// Implementations may use any strategy for locating and loading
-        /// symbols.
-        async fn locate_symbols(
-            &mut self,
-            module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError>;
-
-        /// Locate a specific file associated with a `module`
-        ///
-        /// Implementations may use any strategy for locating and loading
-        /// symbols.
-        async fn locate_file(
-            &self,
-            module: &(dyn Module + Sync),
-            file_kind: FileKind,
-        ) -> Result<PathBuf, FileError>;
-    }
-
-    /// A trait for setting symbol information on something like a stack frame.
-    pub trait FrameSymbolizer {
-        /// Get the program counter value for this frame.
-        fn get_instruction(&self) -> u64;
-        /// Set the name, base address, and paramter size of the function in
-        // which this frame is executing.
-        fn set_function(&mut self, name: &str, base: u64, parameter_size: u32);
-        /// Set the source file and (1-based) line number this frame represents.
-        fn set_source_file(&mut self, file: &str, line: u32, base: u64);
-    }
-
-    pub trait FrameWalker {
-        /// Get the instruction address that we're trying to unwind from.
-        fn get_instruction(&self) -> u64;
-        /// Get the number of bytes the callee's callee's parameters take up
-        /// on the stack (or 0 if unknown/invalid). This is needed for
-        /// STACK WIN unwinding.
-        fn get_grand_callee_parameter_size(&self) -> u32;
-        /// Get a register-sized value stored at this address.
-        fn get_register_at_address(&self, address: u64) -> Option<u64>;
-        /// Get the value of a register from the callee's frame.
-        fn get_callee_register(&self, name: &str) -> Option<u64>;
-        /// Set the value of a register for the caller's frame.
-        fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()>;
-        /// Explicitly mark one of the caller's registers as invalid.
-        fn clear_caller_register(&mut self, name: &str);
-        /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
-        fn set_cfa(&mut self, val: u64) -> Option<()>;
-        /// Set whatever registers in the caller should be set based on the return address (e.g. rip).
-        fn set_ra(&mut self, val: u64) -> Option<()>;
-    }
-
-    /// Symbolicate stack frames.
-    ///
-    /// A `Symbolizer` manages loading symbols and looking up symbols in them
-    /// including caching so that symbols for a given module are only loaded once.
-    ///
-    /// Call [`Symbolizer::new`][new] to instantiate a `Symbolizer`. A Symbolizer
-    /// requires a [`SymbolSupplier`][supplier] to locate symbols. If you have
-    /// symbols on disk in the [customary directory layout][dirlayout], a
-    /// [`SimpleSymbolSupplier`][simple] will work.
-    ///
-    /// Use [`get_symbol_at_address`][get_symbol] or [`fill_symbol`][fill_symbol] to
-    /// do symbol lookup.
-    ///
-    /// [new]: struct.Symbolizer.html#method.new
-    /// [supplier]: trait.SymbolSupplier.html
-    /// [dirlayout]: fn.relative_symbol_path.html
-    /// [simple]: struct.SimpleSymbolSupplier.html
-    /// [get_symbol]: struct.Symbolizer.html#method.get_symbol_at_address
-    /// [fill_symbol]: struct.Symbolizer.html#method.fill_symbol
-    pub struct Symbolizer {
-        /// Symbol supplier for locating symbols.
-        supplier: Box<dyn SymbolSupplier + 'static + Send + Sync>,
-    }
-
-    impl Symbolizer {
-        /// Create a `Symbolizer` that uses `supplier` to locate symbols.
-        pub fn new<T: SymbolSupplier + 'static + Send + Sync>(supplier: T) -> Symbolizer {
-            Symbolizer {
-                supplier: Box::new(supplier),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl SymbolProvider for Symbolizer {
-        async fn fill_symbol(
-            &self,
-            _module: &(dyn Module + Sync),
-            _frame: &mut (dyn FrameSymbolizer + Send),
-        ) -> Result<(), FillSymbolError> {
-            unimplemented!()
-        }
-        async fn walk_frame(
-            &self,
-            _module: &(dyn Module + Sync),
-            _walker: &mut (dyn FrameWalker + Send),
-        ) -> Option<()> {
-            unimplemented!()
-        }
-        fn stats(&self) -> HashMap<String, SymbolStats> {
-            unimplemented!()
-        }
-        async fn get_file_path(
-            &self,
-            module: &(dyn Module + Sync),
-            file_kind: FileKind,
-        ) -> Result<PathBuf, FileError> {
-            unimplemented!()
-        }
-    }
-
-    /// Gets a SymbolSupplier that looks up symbols by path or with urls.
-    ///
-    /// * `symbols_paths` is a list of paths to check for symbol files. Paths
-    ///   are searched in order until one returns a payload. If none do, then
-    ///   urls are used.
-    ///
-    /// * `symbols_urls` is a list of "base urls" that should all point to Tecken
-    ///   servers. urls are queried in order until one returns a payload. If none
-    ///   do, then it's an error.
-    ///
-    /// * `symbols_cache` is a directory where an on-disk cache should be located.
-    ///   This should be assumed to be a "temp" directory that another process
-    ///   you don't control is garbage-collecting old files from (to provide an LRU cache).
-    ///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
-    ///
-    /// * `symbols_tmp` is a directory where symbol files should be downloaded to
-    ///   before atomically swapping them into the cache. Has the same "temp"
-    ///   assumptions as symbols_cache.
-    ///
-    /// * `timeout` a maximum time limit (in seconds) for a symbol file download. This
-    ///   is primarily defined to avoid getting stuck on buggy infinite downloads.
-    ///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
-    ///   the event of a timeout, the supplier may still try to parse the truncated
-    ///   download.
-    pub fn http_symbol_supplier(
-        _symbol_paths: Vec<PathBuf>,
-        _symbol_urls: Vec<String>,
-        _symbols_cache: PathBuf,
-        _symbols_tmp: PathBuf,
-        _timeout: Duration,
-    ) -> impl SymbolSupplier {
-        HttpSymbolSupplier {}
-    }
-
-    /// Gets a SymbolSupplier that looks up symbols by path.
-    ///
-    /// Paths are queried in order until one returns a payload.
-    pub fn simple_symbol_supplier(_symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
-        SimpleSymbolSupplier {}
-    }
-
-    /// Gets a mock SymbolSupplier that just maps module names
-    /// to a string containing an entire breakpad .sym file, for tests.
-    pub fn string_symbol_supplier(_modules: HashMap<String, String>) -> impl SymbolSupplier {
-        StringSymbolSupplier {}
-    }
-
-    /// A type of file related to a module that you might want downloaded.
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub enum FileKind {
-        /// A Breakpad symbol (.sym) file
-        BreakpadSym,
-        /// The native binary of a module ("code file") (.exe/.dll/.so/.dylib...)
-        Binary,
-        /// Extra debuginfo for a module ("debug file") (.pdb/...?)
-        ExtraDebugInfo,
-    }
-
-    /// Possible results of locating symbols for a module.
-    ///
-    /// Because symbols may be found from different sources, symbol providers
-    /// are usually configured to "cascade" into the next one whenever they report
-    /// `NotFound`.
-    ///
-    /// Cascading currently assumes that if any provider finds symbols for
-    /// a module, all other providers will find the same symbols (if any).
-    /// Therefore cascading will not be applied if a LoadError or ParseError
-    /// occurs (because presumably, all the other sources will also fail to
-    /// load/parse.)
-    ///
-    /// In theory we could do some interesting things where we attempt to
-    /// be more robust and actually merge together the symbols from multiple
-    /// sources, but that would make it difficult to cache symbol files, and
-    /// would rarely actually improve results.
-    ///
-    /// Since symbol files can be on the order of a gigabyte(!) and downloaded
-    /// from the network, aggressive caching is pretty important. The current
-    /// approach is a nice balance of simple and effective.
-    #[derive(Debug)]
-    pub enum SymbolError {
-        /// Symbol file could not be found.
-        ///
-        /// In this case other symbol providers may still be able to find it!
-        NotFound,
-        /// Symbol file could not be loaded into memory.
-        LoadError,
-        /// Symbol file was too corrupt to be parsed at all.
-        ///
-        /// Because symbol files are pretty modular, many corruptions/ambiguities
-        /// can be either repaired or discarded at a fairly granular level
-        /// (e.g. a bad STACK WIN line can be discarded without affecting anything
-        /// else). But sometimes we can't make any sense of the symbol file, and
-        /// you find yourself here.
-        ParseError,
-    }
-
-    #[derive(Clone, Debug, thiserror::Error)]
-    pub enum FileError {
-        #[error("file not found")]
-        NotFound,
-    }
-
-    #[derive(Debug)]
-    pub struct FillSymbolError {}
-
-    // Whatever representation you want, rust-minidump won't look at it.
-    pub struct SymbolFile {}
-
-    /// Statistics on the symbols of a module.
-    #[derive(Default, Debug)]
-    pub struct SymbolStats {
-        /// If the module's symbols were downloaded, this is the url used.
-        pub symbol_url: Option<String>,
-        /// If the symbols were found and loaded into memory.
-        pub loaded_symbols: bool,
-        /// If we tried to parse the symbols, but failed.
-        pub corrupt_symbols: bool,
-    }
-
-    // These suppliers are entriely private to the implementation, so do whatever you
-    // want with them.
-
-    struct HttpSymbolSupplier {}
-
-    struct SimpleSymbolSupplier {}
-
-    struct StringSymbolSupplier {}
-
-    #[async_trait]
-    impl SymbolSupplier for HttpSymbolSupplier {
-        async fn locate_symbols(
-            &mut self,
-            _module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError> {
-            unimplemented!()
-        }
-    }
-
-    #[async_trait]
-    impl SymbolSupplier for SimpleSymbolSupplier {
-        async fn locate_symbols(
-            &mut self,
-            _module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError> {
-            unimplemented!()
-        }
-    }
-
-    #[async_trait]
-    impl SymbolSupplier for StringSymbolSupplier {
-        async fn locate_symbols(
-            &mut self,
-            _module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError> {
-            unimplemented!()
-        }
-    }
+/// Gets a mock SymbolSupplier that just maps module names
+/// to a string containing an entire breakpad .sym file, for tests.
+pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
+    breakpad_symbols::StringSymbolSupplier::new(modules)
 }


### PR DESCRIPTION
As a first step to follow up on the discussions in https://github.com/rust-minidump/rust-minidump/pull/576.

This just removes the two feature flags and the unused/incomplete symbolic-syms code completely.
Its a first step and we can do more simplifications on top of this later.