### PR TITLE
ref: Move SymbolSupplier out of the processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
 name = "minidump-stackwalk"
 version = "0.11.0"
 dependencies = [
+ "breakpad-symbols",
  "clap 3.2.5",
  "insta",
  "minidump",

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -68,6 +68,19 @@ pub mod fuzzing_private_exports {
     pub use crate::sym_file::{StackInfoWin, WinStackThing};
 }
 
+/// Gets a SymbolSupplier that looks up symbols by path.
+///
+/// Paths are queried in order until one returns a payload.
+pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
+    SimpleSymbolSupplier::new(symbol_paths)
+}
+
+/// Gets a mock SymbolSupplier that just maps module names
+/// to a string containing an entire breakpad .sym file, for tests.
+pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
+    StringSymbolSupplier::new(modules)
+}
+
 /// Statistics on the symbols of a module.
 #[derive(Default, Debug)]
 pub struct SymbolStats {

--- a/minidump-processor/README.md
+++ b/minidump-processor/README.md
@@ -16,15 +16,16 @@ For a CLI application that wraps this library, see [minidump-stackwalk](https://
 If you do need to use minidump-processor as a library, we still recommend using the stabilized JSON output. The native APIs work fine and contain all the same information, we just haven't stabilized them yet, so updates are more likely to result in breakage. Here is a minimal example which gets the JSON output (and parses it with serde_json):
 
 ```rust
+use breakpad_symbols::http_symbol_supplier;
 use minidump::Minidump;
-use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
+use minidump_processor::{ProcessorOptions, Symbolizer};
 use serde_json::Value;
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     // Read the minidump
     let dump = Minidump::read_path("../testdata/test.dmp").map_err(|_| ())?;
- 
+
     // Configure the symbolizer and processor
     let symbols_urls = vec![String::from("https://symbols.totallyrealwebsite.org")];
     let symbols_paths = vec![];
@@ -32,7 +33,7 @@ async fn main() -> Result<(), ()> {
     symbols_cache.push("minidump-cache");
     let symbols_tmp = std::env::temp_dir();
     let timeout = std::time::Duration::from_secs(1000);
- 
+
     // Use ProcessorOptions for detailed configuration
     let options = ProcessorOptions::default();
 
@@ -44,7 +45,7 @@ async fn main() -> Result<(), ()> {
         symbols_tmp,
         timeout,
     ));
- 
+
     let state = minidump_processor::process_minidump_with_options(&dump, &provider, options)
         .await
         .map_err(|_| ())?;

--- a/minidump-processor/fuzz/Cargo.toml
+++ b/minidump-processor/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+breakpad-symbols = { path = "../../breakpad-symbols" }
 libfuzzer-sys = "0.4"
 minidump = { path = "../../minidump", features = ["arbitrary_impls"] }
 test-assembler = "0.1.6"

--- a/minidump-processor/fuzz/fuzz_targets/process.rs
+++ b/minidump-processor/fuzz/fuzz_targets/process.rs
@@ -6,19 +6,19 @@ struct StaticSymbolSupplier {
 }
 
 #[async_trait::async_trait]
-impl minidump_processor::SymbolSupplier for StaticSymbolSupplier {
+impl breakpad_symbols::SymbolSupplier for StaticSymbolSupplier {
     async fn locate_symbols(
         &self,
         _module: &(dyn minidump_common::traits::Module + Sync),
-    ) -> Result<minidump_processor::SymbolFile, minidump_processor::SymbolError> {
-        minidump_processor::SymbolFile::from_bytes(&self.file)
+    ) -> Result<breakpad_symbols::SymbolFile, breakpad_symbols::SymbolError> {
+        breakpad_symbols::SymbolFile::from_bytes(&self.file)
     }
     async fn locate_file(
         &self,
         _module: &(dyn minidump_common::traits::Module + Sync),
-        _file_kind: minidump_processor::FileKind,
-    ) -> Result<std::path::PathBuf, minidump_processor::FileError> {
-        Err(minidump_processor::FileError::NotFound)
+        _file_kind: breakpad_symbols::FileKind,
+    ) -> Result<std::path::PathBuf, breakpad_symbols::FileError> {
+        Err(breakpad_symbols::FileError::NotFound)
     }
 }
 
@@ -28,7 +28,7 @@ fuzz_target!(|data: (&[u8], &[u8])| {
             file: data.1.to_vec(),
         };
 
-        let provider = minidump_processor::Symbolizer::new(supplier);
+        let provider = breakpad_symbols::Symbolizer::new(supplier);
         // Fuzz every possible feature
         let options = minidump_processor::ProcessorOptions::unstable_all();
 

--- a/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
+++ b/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
@@ -1,11 +1,12 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
+use breakpad_symbols::{string_symbol_supplier, Symbolizer};
 use minidump::system_info::{Cpu, Os};
 use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory};
 use minidump::{MinidumpModule, MinidumpModuleList};
 use minidump_processor::walk_stack;
-use minidump_processor::{string_symbol_supplier, CallStack, Symbolizer, SystemInfo};
+use minidump_processor::{CallStack, SystemInfo};
 use std::collections::HashMap;
 use test_assembler::Section;
 

--- a/minidump-processor/src/lib.rs
+++ b/minidump-processor/src/lib.rs
@@ -17,8 +17,9 @@
 //! (and parses it with serde_json):
 //!  
 //! ```rust
+//! use breakpad_symbols::http_symbol_supplier;
 //! use minidump::Minidump;
-//! use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
+//! use minidump_processor::{ProcessorOptions, Symbolizer};
 //! use serde_json::Value;
 //!  
 //! #[tokio::main]

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -1,14 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::format::CONTEXT_AMD64;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 struct TestFixture {
     pub raw: CONTEXT_AMD64,

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -4,13 +4,16 @@
 // NOTE: we don't bother testing arm64_old, it should have identical code at
 // all times!
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 type Context = minidump::format::CONTEXT_ARM64;
 

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -1,14 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::format::CONTEXT_ARM;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 struct TestFixture {
     pub raw: CONTEXT_ARM,

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -1,14 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::format::CONTEXT_X86;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 struct TestFixture {
     pub raw: CONTEXT_X86,

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -10,11 +10,6 @@
 //!       SymbolProviders have been removed, but I figured it would be a waste to throw out
 //!       this minimally intrusive machinery.
 //!
-//! * [SymbolSupplier][] - maps a [Module][] to a [SymbolFile][]
-//!     * minidump-processor does not directly use this, it's just there so the Symbolizer can
-//!       generically handle different symbol fetching strategies (which minidump-processor
-//!       selects and configures).
-//!
 //!
 //!
 //! While minidump-processor provides implementations of these traits:
@@ -27,20 +22,12 @@
 //!
 //!
 //!
-//! The symbolizer is responsible for providing the following concrete functions, which
-//! minidump-processor uses to select and configure the symbol fetching strategy:
-//!
-//! * [http_symbol_supplier][] - a [SymbolSupplier][] that can find symbols over HTTP (and cache).
-//! * [simple_symbol_supplier][] - a [SymbolSupplier][] that can find symbols on disk.
-//! * [string_symbol_supplier][] - a mock [SymbolSupplier][] for tests.
-//!
-//!
 //!
 //! And the following concrete types:
 //!
 //! * [Symbolizer][] - the main interface of the symbolizer, implementing [SymbolProvider][].
-//!     * Wraps the [SymbolSupplier][] implementation that minidump-processor selects.
-//!     * Queries the [SymbolSupplier] and manages the SymbolFiles however it pleases.
+//!     * Wraps the [SymbolSupplier][breakpad_symbols::Symbolizer] implementation that minidump-processor selects.
+//!     * Queries the [SymbolSupplier][breakpad_symbols::Symbolizer] and manages the SymbolFiles however it pleases.
 //! * [SymbolStats][] - debug statistic output.
 //! * [SymbolFile][] - a payload that a [SymbolProvider][] returns to the Symbolizer.
 //!     * Never handled by minidump-processor, public for the trait. (use this for whatever)
@@ -55,8 +42,9 @@
 //! # Example
 //!
 //! ```rust
+//! use breakpad_symbols::http_symbol_supplier;
 //! use minidump::Minidump;
-//! use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
+//! use minidump_processor::{ProcessorOptions, Symbolizer};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), ()> {
@@ -97,7 +85,7 @@ use minidump::Module;
 
 pub use breakpad_symbols::{
     FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolError, SymbolFile,
-    SymbolStats, SymbolSupplier, Symbolizer,
+    SymbolStats, Symbolizer,
 };
 
 #[async_trait]
@@ -218,58 +206,4 @@ impl SymbolProvider for Symbolizer {
     fn stats(&self) -> HashMap<String, SymbolStats> {
         self.stats()
     }
-}
-
-/// Gets a SymbolSupplier that looks up symbols by path or with urls.
-///
-/// * `symbols_paths` is a list of paths to check for symbol files. Paths
-///   are searched in order until one returns a payload. If none do, then
-///   urls are used.
-///
-/// * `symbols_urls` is a list of "base urls" that should all point to Tecken
-///   servers. urls are queried in order until one returns a payload. If none
-///   do, then it's an error.
-///
-/// * `symbols_cache` is a directory where an on-disk cache should be located.
-///   This should be assumed to be a "temp" directory that another process
-///   you don't control is garbage-collecting old files from (to provide an LRU cache).
-///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
-///
-/// * `symbols_tmp` is a directory where symbol files should be downloaded to
-///   before atomically swapping them into the cache. Has the same "temp"
-///   assumptions as symbols_cache.
-///
-/// * `timeout` a maximum time limit for a symbol file download. This
-///   is primarily defined to avoid getting stuck on buggy infinite downloads.
-///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
-///   the event of a timeout, the supplier may still try to parse the truncated
-///   download.
-#[cfg(feature = "http")]
-pub fn http_symbol_supplier(
-    symbol_paths: Vec<PathBuf>,
-    symbol_urls: Vec<String>,
-    symbols_cache: PathBuf,
-    symbols_tmp: PathBuf,
-    timeout: std::time::Duration,
-) -> impl SymbolSupplier {
-    breakpad_symbols::HttpSymbolSupplier::new(
-        symbol_urls,
-        symbols_cache,
-        symbols_tmp,
-        symbol_paths,
-        timeout,
-    )
-}
-
-/// Gets a SymbolSupplier that looks up symbols by path.
-///
-/// Paths are queried in order until one returns a payload.
-pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
-    breakpad_symbols::SimpleSymbolSupplier::new(symbol_paths)
-}
-
-/// Gets a mock SymbolSupplier that just maps module names
-/// to a string containing an entire breakpad .sym file, for tests.
-pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
-    breakpad_symbols::StringSymbolSupplier::new(modules)
 }

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -1,15 +1,14 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
+use std::path::{Path, PathBuf};
+
+use breakpad_symbols::simple_symbol_supplier;
 use minidump::system_info::{Cpu, Os};
 use minidump::{
     Error, Minidump, MinidumpContext, MinidumpContextValidity, MinidumpRawContext, Module,
 };
-use minidump_processor::{
-    simple_symbol_supplier, CallStackInfo, FrameTrust, LinuxStandardBase, ProcessState, Symbolizer,
-};
-use std::path::{Path, PathBuf};
-
+use minidump_processor::{CallStackInfo, FrameTrust, LinuxStandardBase, ProcessState, Symbolizer};
 use minidump_synth::*;
 use test_assembler::*;
 

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -21,6 +21,7 @@ dump_syms = ["minidump-processor/dump_syms"]
 mozilla_cab_symbols = ["minidump-processor/mozilla_cab_symbols"]
 
 [dependencies]
+breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols" }
 clap = { version = "3.1", features = ["cargo", "wrap_help", "derive"] }
 minidump = { version = "0.11.0", path = "../minidump" }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -8,10 +8,9 @@ use std::panic;
 use std::time::Duration;
 use std::{boxed::Box, path::PathBuf};
 
+use breakpad_symbols::{http_symbol_supplier, simple_symbol_supplier};
 use minidump::*;
-use minidump_processor::{
-    http_symbol_supplier, simple_symbol_supplier, MultiSymbolProvider, ProcessorOptions, Symbolizer,
-};
+use minidump_processor::{MultiSymbolProvider, ProcessorOptions, Symbolizer};
 
 use clap::{AppSettings, ArgGroup, CommandFactory, Parser};
 use tracing::error;


### PR DESCRIPTION
The SymbolSupplier was so far re-exported from breakpad-symbols along
with some constructor functions.

This is on top of #613 and just moves some things out of `minidump-processor`.