### PR TITLE
ref: Reverse the dependency between breakpad-symbols and minidump-processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "debugid 0.8.0",
  "dump_syms",
  "minidump-common",
+ "minidump-processor",
  "nom",
  "range-map",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
 name = "minidump-stackwalk"
 version = "0.11.0"
 dependencies = [
+ "breakpad-symbols",
  "clap 3.2.5",
  "insta",
  "minidump",

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -18,6 +18,9 @@ travis-ci = { repository = "rust-minidump/rust-minidump" }
 fuzz = []
 # Allow retrieval of symbols via HTTP
 http = ["reqwest", "tempfile"]
+# Allows construction of symbol files from native binaries
+dump_syms = ["dep:dump_syms", "http"]
+# Allows retrieval of CABed symbol files from mozilla servers
 mozilla_cab_symbols = ["http", "cab"]
 
 [dependencies]
@@ -28,6 +31,7 @@ debugid = "0.8.0"
 dump_syms = { version = "1.0.1", optional = true }
 tracing = { version = "0.1.34", features = ["log"] }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
+minidump-processor = { version = "0.11.0", path = "../minidump-processor" }
 nom = "7"
 range-map = "0.1.5"
 reqwest = { version = "0.11.6", default-features = false, features = [

--- a/breakpad-symbols/src/http.rs
+++ b/breakpad-symbols/src/http.rs
@@ -1,6 +1,7 @@
 //! Contains HTTP symbol retrieval specific functionality
 
 use crate::*;
+use minidump_processor::{FileError, FileKind};
 use reqwest::{Client, Url};
 use std::fs;
 use std::io::{self, Write};

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -68,6 +68,19 @@ pub mod fuzzing_private_exports {
     pub use crate::sym_file::{StackInfoWin, WinStackThing};
 }
 
+/// Gets a SymbolSupplier that looks up symbols by path.
+///
+/// Paths are queried in order until one returns a payload.
+pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
+    SimpleSymbolSupplier::new(symbol_paths)
+}
+
+/// Gets a mock SymbolSupplier that just maps module names
+/// to a string containing an entire breakpad .sym file, for tests.
+pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
+    StringSymbolSupplier::new(modules)
+}
+
 /// Statistics on the symbols of a module.
 #[derive(Default, Debug)]
 pub struct SymbolStats {

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -37,10 +37,6 @@
 //! }
 //! ```
 
-use async_trait::async_trait;
-use debugid::{CodeId, DebugId};
-use tracing::trace;
-
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::fs;
@@ -48,14 +44,23 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::{borrow::Cow, sync::Arc};
 
-pub use minidump_common::{traits::Module, utils::basename};
-pub use sym_file::walker;
+use async_trait::async_trait;
+use debugid::{CodeId, DebugId};
+use minidump_processor::{FileError, FileKind, FrameSymbolizer, FrameWalker};
+use tracing::trace;
 
-pub use crate::sym_file::{CfiRules, SymbolFile};
+pub use minidump_common::{traits::Module, utils::basename};
+
+pub use sym_file::{walker, CfiRules, SymbolFile};
 
 #[cfg(feature = "http")]
 pub mod http;
+mod multi_provider;
 mod sym_file;
+mod symbolizer;
+
+pub use multi_provider::MultiSymbolProvider;
+pub use symbolizer::Symbolizer;
 
 #[cfg(feature = "http")]
 pub use http::*;
@@ -79,17 +84,6 @@ pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier
 /// to a string containing an entire breakpad .sym file, for tests.
 pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
     StringSymbolSupplier::new(modules)
-}
-
-/// Statistics on the symbols of a module.
-#[derive(Default, Debug)]
-pub struct SymbolStats {
-    /// If the module's symbols were downloaded, this is the url used.
-    pub symbol_url: Option<String>,
-    /// If the symbols were found and loaded into memory.
-    pub loaded_symbols: bool,
-    /// If we tried to parse the symbols, but failed.
-    pub corrupt_symbols: bool,
 }
 
 /// A `Module` implementation that holds arbitrary data.
@@ -301,29 +295,6 @@ pub enum SymbolError {
     ParseError(&'static str, u64),
 }
 
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum FileError {
-    #[error("file not found")]
-    NotFound,
-}
-
-/// An error produced by fill_symbol.
-#[derive(Debug)]
-pub struct FillSymbolError {
-    // We don't want to yield a full SymbolError for fill_symbol
-    // as this would involve cloning bulky Error strings every time
-    // someone requested symbols for a missing module.
-    //
-    // As it turns out there's currently no reason to care about *why*
-    // fill_symbol, so for now this is just a dummy type until we have
-    // something to put here.
-    //
-    // The only reason fill_symbol *can* produce an Err is so that
-    // the caller can distinguish between "we had symbols, but this address
-    // didn't map to a function name" and "we had no symbols for that module"
-    // (this is used as a heuristic for stack scanning).
-}
-
 impl PartialEq for SymbolError {
     fn eq(&self, other: &SymbolError) -> bool {
         matches!(
@@ -355,6 +326,8 @@ pub trait SymbolSupplier {
         file_kind: FileKind,
     ) -> Result<PathBuf, FileError>;
 }
+
+pub(crate) type CachedOperation<T, E> = Arc<tokio::sync::OnceCell<Result<T, E>>>;
 
 /// An implementation of `SymbolSupplier` that loads Breakpad text-format symbols from local disk
 /// paths.
@@ -456,40 +429,6 @@ impl SymbolSupplier for StringSymbolSupplier {
     }
 }
 
-/// A trait for setting symbol information on something like a stack frame.
-pub trait FrameSymbolizer {
-    /// Get the program counter value for this frame.
-    fn get_instruction(&self) -> u64;
-    /// Set the name, base address, and paramter size of the function in
-    // which this frame is executing.
-    fn set_function(&mut self, name: &str, base: u64, parameter_size: u32);
-    /// Set the source file and (1-based) line number this frame represents.
-    fn set_source_file(&mut self, file: &str, line: u32, base: u64);
-}
-
-pub trait FrameWalker {
-    /// Get the instruction address that we're trying to unwind from.
-    fn get_instruction(&self) -> u64;
-    /// Check whether the callee has a callee of its own.
-    fn has_grand_callee(&self) -> bool;
-    /// Get the number of bytes the callee's callee's parameters take up
-    /// on the stack (or 0 if unknown/invalid). This is needed for
-    /// STACK WIN unwinding.
-    fn get_grand_callee_parameter_size(&self) -> u32;
-    /// Get a register-sized value stored at this address.
-    fn get_register_at_address(&self, address: u64) -> Option<u64>;
-    /// Get the value of a register from the callee's frame.
-    fn get_callee_register(&self, name: &str) -> Option<u64>;
-    /// Set the value of a register for the caller's frame.
-    fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()>;
-    /// Explicitly mark one of the caller's registers as invalid.
-    fn clear_caller_register(&mut self, name: &str);
-    /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
-    fn set_cfa(&mut self, val: u64) -> Option<()>;
-    /// Set whatever registers in the caller should be set based on the return address (e.g. rip).
-    fn set_ra(&mut self, val: u64) -> Option<()>;
-}
-
 /// A simple implementation of `FrameSymbolizer` that just holds data.
 #[derive(Debug, Default)]
 pub struct SimpleFrame {
@@ -536,17 +475,6 @@ impl FrameSymbolizer for SimpleFrame {
     }
 }
 
-/// A type of file related to a module that you might want downloaded.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum FileKind {
-    /// A Breakpad symbol (.sym) file
-    BreakpadSym,
-    /// The native binary of a module ("code file") (.exe/.dll/.so/.dylib...)
-    Binary,
-    /// Extra debuginfo for a module ("debug file") (.pdb/...?)
-    ExtraDebugInfo,
-}
-
 // Can't make Module derive Hash, since then it can't be used as a trait
 // object (because the hash method is generic), so this is a hacky workaround.
 /// A key that uniquely identifies a module:
@@ -565,204 +493,6 @@ fn module_key(module: &(dyn Module + Sync)) -> ModuleKey {
         module.debug_file().map(|s| s.to_string()),
         module.debug_identifier().map(|s| s.to_string()),
     )
-}
-
-/// Symbolicate stack frames.
-///
-/// A `Symbolizer` manages loading symbols and looking up symbols in them
-/// including caching so that symbols for a given module are only loaded once.
-///
-/// Call [`Symbolizer::new`][new] to instantiate a `Symbolizer`. A Symbolizer
-/// requires a [`SymbolSupplier`][supplier] to locate symbols. If you have
-/// symbols on disk in the [customary directory layout][breakpad_sym_lookup], a
-/// [`SimpleSymbolSupplier`][simple] will work.
-///
-/// Use [`get_symbol_at_address`][get_symbol] or [`fill_symbol`][fill_symbol] to
-/// do symbol lookup.
-///
-/// [new]: struct.Symbolizer.html#method.new
-/// [supplier]: trait.SymbolSupplier.html
-/// [simple]: struct.SimpleSymbolSupplier.html
-/// [get_symbol]: struct.Symbolizer.html#method.get_symbol_at_address
-/// [fill_symbol]: struct.Symbolizer.html#method.fill_symbol
-
-type CachedOperation<T, E> = Arc<tokio::sync::OnceCell<Result<T, E>>>;
-
-pub struct Symbolizer {
-    /// Symbol supplier for locating symbols.
-    supplier: Box<dyn SymbolSupplier + Send + Sync + 'static>,
-    /// Cache of symbol locating results.
-    // TODO?: use lru-cache: https://crates.io/crates/lru-cache/
-    // note that using an lru-cache would mess up the fact that we currently
-    // use this for statistics collection. Splitting out statistics would be
-    // way messier but not impossible.
-    symbols: Mutex<HashMap<ModuleKey, CachedOperation<SymbolFile, SymbolError>>>,
-}
-
-impl Symbolizer {
-    /// Create a `Symbolizer` that uses `supplier` to locate symbols.
-    pub fn new<T: SymbolSupplier + Send + Sync + 'static>(supplier: T) -> Symbolizer {
-        Symbolizer {
-            supplier: Box::new(supplier),
-            symbols: Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Helper method for non-minidump-using callers.
-    ///
-    /// Pass `debug_file` and `debug_id` describing a specific module,
-    /// and `address`, a module-relative address, and get back
-    /// a symbol in that module that covers that address, or `None`.
-    ///
-    /// See [the module-level documentation][module] for an example.
-    ///
-    /// [module]: index.html
-    pub async fn get_symbol_at_address(
-        &self,
-        debug_file: &str,
-        debug_id: DebugId,
-        address: u64,
-    ) -> Option<String> {
-        let k = (debug_file, debug_id);
-        let mut frame = SimpleFrame::with_instruction(address);
-        self.fill_symbol(&k, &mut frame).await.ok()?;
-        frame.function
-    }
-
-    /// Fill symbol information in `frame` using the instruction address
-    /// from `frame`, and the module information from `module`. If you're not
-    /// using a minidump module, you can use [`SimpleModule`][simplemodule] and
-    /// [`SimpleFrame`][simpleframe].
-    ///
-    /// An Error indicates that no symbols could be found for the relevant
-    /// module.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # std::env::set_current_dir(env!("CARGO_MANIFEST_DIR"));
-    /// use std::str::FromStr;
-    /// use debugid::DebugId;
-    /// use breakpad_symbols::{SimpleSymbolSupplier,Symbolizer,SimpleFrame,SimpleModule};
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     use std::path::PathBuf;
-    ///     let paths = vec!(PathBuf::from("../testdata/symbols/"));
-    ///     let supplier = SimpleSymbolSupplier::new(paths);
-    ///     let symbolizer = Symbolizer::new(supplier);
-    ///     let debug_id = DebugId::from_str("5A9832E5287241C1838ED98914E9B7FF1").unwrap();
-    ///     let m = SimpleModule::new("test_app.pdb", debug_id);
-    ///     let mut f = SimpleFrame::with_instruction(0x1010);
-    ///     let _ = symbolizer.fill_symbol(&m, &mut f).await;
-    ///     assert_eq!(f.function.unwrap(), "vswprintf");
-    ///     assert_eq!(f.source_file.unwrap(),
-    ///         r"c:\program files\microsoft visual studio 8\vc\include\swprintf.inl");
-    ///     assert_eq!(f.source_line.unwrap(), 51);
-    /// }
-    /// ```
-    ///
-    /// [simplemodule]: struct.SimpleModule.html
-    /// [simpleframe]: struct.SimpleFrame.html
-    pub async fn fill_symbol(
-        &self,
-        module: &(dyn Module + Sync),
-        frame: &mut (dyn FrameSymbolizer + Send),
-    ) -> Result<(), FillSymbolError> {
-        let cached_sym = self.get_symbols(module).await;
-        let sym = cached_sym
-            .get()
-            .unwrap()
-            .as_ref()
-            .map_err(|_| FillSymbolError {})?;
-        sym.fill_symbol(module, frame);
-        Ok(())
-    }
-
-    /// Collect various statistics on the symbols.
-    ///
-    /// Keys are the file name of the module (code_file's file name).
-    pub fn stats(&self) -> HashMap<String, SymbolStats> {
-        self.symbols
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(k, res)| {
-                let res = res.get().expect("Had uninitialized SymbolFile entry?");
-                let mut stats = SymbolStats::default();
-                match res {
-                    Ok(sym) => {
-                        stats.symbol_url = sym.url.clone();
-                        stats.loaded_symbols = true;
-                        stats.corrupt_symbols = false;
-                    }
-                    Err(SymbolError::NotFound) => {
-                        stats.loaded_symbols = false;
-                    }
-                    Err(SymbolError::MissingDebugFileOrId) => {
-                        stats.loaded_symbols = false;
-                    }
-                    Err(SymbolError::LoadError(_)) => {
-                        stats.loaded_symbols = false;
-                    }
-                    Err(SymbolError::ParseError(..)) => {
-                        stats.loaded_symbols = true;
-                        stats.corrupt_symbols = true;
-                    }
-                }
-                (leafname(&k.0).to_string(), stats)
-            })
-            .collect()
-    }
-
-    /// Tries to use CFI to walk the stack frame of the FrameWalker
-    /// using the symbols of the given Module. Output will be written
-    /// using the FrameWalker's `set_caller_*` APIs.
-    pub async fn walk_frame(
-        &self,
-        module: &(dyn Module + Sync),
-        walker: &mut (dyn FrameWalker + Send),
-    ) -> Option<()> {
-        let cached_sym = self.get_symbols(module).await;
-        let sym = cached_sym.get().unwrap().as_ref();
-        if let Ok(sym) = sym {
-            trace!("found symbols for address, searching for cfi entries");
-            sym.walk_frame(module, walker)
-        } else {
-            trace!("couldn't find symbols for address, cannot use cfi");
-            None
-        }
-    }
-
-    /// Gets the fully parsed SymbolFile for a given module (or an Error).
-    ///
-    /// This returns a CachedOperation which is guaranteed to already be resolved (lifetime stuff).
-    async fn get_symbols(
-        &self,
-        module: &(dyn Module + Sync),
-    ) -> CachedOperation<SymbolFile, SymbolError> {
-        // This clones an Arc<Once> that we will use to only do this operation once
-        let k = module_key(module);
-        let symbol_once = self.symbols.lock().unwrap().entry(k).or_default().clone();
-        symbol_once
-            .get_or_init(|| async {
-                trace!("locating symbols for module {}", module.code_file());
-                self.supplier.locate_symbols(module).await
-            })
-            .await;
-        symbol_once
-    }
-
-    /// Gets the path to a file for a given module (or an Error).
-    ///
-    /// This returns a CachedOperation which is guaranteed to already be resolved (lifetime stuff).
-    pub async fn get_file_path(
-        &self,
-        module: &(dyn Module + Sync),
-        file_kind: FileKind,
-    ) -> Result<PathBuf, FileError> {
-        self.supplier.locate_file(module, file_kind).await
-    }
 }
 
 #[test]

--- a/breakpad-symbols/src/multi_provider.rs
+++ b/breakpad-symbols/src/multi_provider.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use minidump_common::traits::Module;
+use minidump_processor::{
+    FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolProvider, SymbolStats,
+};
+
+#[derive(Default)]
+pub struct MultiSymbolProvider {
+    providers: Vec<Box<dyn SymbolProvider + Send + Sync>>,
+}
+
+impl MultiSymbolProvider {
+    pub fn new() -> MultiSymbolProvider {
+        Default::default()
+    }
+
+    pub fn add(&mut self, provider: Box<dyn SymbolProvider + Send + Sync>) {
+        self.providers.push(provider);
+    }
+}
+
+#[async_trait]
+impl SymbolProvider for MultiSymbolProvider {
+    async fn fill_symbol(
+        &self,
+        module: &(dyn Module + Sync),
+        frame: &mut (dyn FrameSymbolizer + Send),
+    ) -> Result<(), FillSymbolError> {
+        // Return Ok if *any* symbol provider came back with Ok, so that the user can
+        // distinguish between having no symbols at all and just not being able to
+        // symbolize this particular frame.
+        let mut best_result = Err(FillSymbolError {});
+        for p in self.providers.iter() {
+            let new_result = p.fill_symbol(module, frame).await;
+            best_result = best_result.or(new_result);
+        }
+        best_result
+    }
+
+    async fn walk_frame(
+        &self,
+        module: &(dyn Module + Sync),
+        walker: &mut (dyn FrameWalker + Send),
+    ) -> Option<()> {
+        for p in self.providers.iter() {
+            let result = p.walk_frame(module, walker).await;
+            if result.is_some() {
+                return result;
+            }
+        }
+        None
+    }
+
+    async fn get_file_path(
+        &self,
+        module: &(dyn Module + Sync),
+        file_kind: FileKind,
+    ) -> Result<PathBuf, FileError> {
+        // Return Ok if *any* symbol provider came back with Ok
+        let mut best_result = Err(FileError::NotFound);
+        for p in self.providers.iter() {
+            let new_result = p.get_file_path(module, file_kind).await;
+            best_result = best_result.or(new_result);
+        }
+        best_result
+    }
+
+    fn stats(&self) -> HashMap<String, SymbolStats> {
+        let mut result = HashMap::new();
+        for p in self.providers.iter() {
+            // FIXME: do more intelligent merging of the stats
+            // (currently doesn't matter as only one provider reports non-empty stats).
+            result.extend(p.stats());
+        }
+        result
+    }
+}

--- a/breakpad-symbols/src/symbolizer.rs
+++ b/breakpad-symbols/src/symbolizer.rs
@@ -1,0 +1,239 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use debugid::DebugId;
+use minidump_common::traits::Module;
+use minidump_processor::{
+    FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolProvider, SymbolStats,
+};
+use tracing::trace;
+
+use crate::{
+    leafname, module_key, CachedOperation, ModuleKey, SimpleFrame, SymbolError, SymbolFile,
+    SymbolSupplier,
+};
+
+/// Symbolicate stack frames.
+///
+/// A `Symbolizer` manages loading symbols and looking up symbols in them
+/// including caching so that symbols for a given module are only loaded once.
+///
+/// Call [`Symbolizer::new`][new] to instantiate a `Symbolizer`. A Symbolizer
+/// requires a [`SymbolSupplier`][supplier] to locate symbols. If you have
+/// symbols on disk in the [customary directory layout][breakpad_sym_lookup], a
+/// [`SimpleSymbolSupplier`][simple] will work.
+///
+/// Use [`get_symbol_at_address`][get_symbol] or [`fill_symbol`][fill_symbol] to
+/// do symbol lookup.
+///
+/// [new]: struct.Symbolizer.html#method.new
+/// [supplier]: trait.SymbolSupplier.html
+/// [simple]: struct.SimpleSymbolSupplier.html
+/// [get_symbol]: struct.Symbolizer.html#method.get_symbol_at_address
+/// [fill_symbol]: struct.Symbolizer.html#method.fill_symbol
+pub struct Symbolizer {
+    /// Symbol supplier for locating symbols.
+    supplier: Box<dyn SymbolSupplier + Send + Sync + 'static>,
+    /// Cache of symbol locating results.
+    // TODO?: use lru-cache: https://crates.io/crates/lru-cache/
+    // note that using an lru-cache would mess up the fact that we currently
+    // use this for statistics collection. Splitting out statistics would be
+    // way messier but not impossible.
+    symbols: Mutex<HashMap<ModuleKey, CachedOperation<SymbolFile, SymbolError>>>,
+}
+
+impl Symbolizer {
+    /// Create a `Symbolizer` that uses `supplier` to locate symbols.
+    pub fn new<T: SymbolSupplier + Send + Sync + 'static>(supplier: T) -> Symbolizer {
+        Symbolizer {
+            supplier: Box::new(supplier),
+            symbols: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Helper method for non-minidump-using callers.
+    ///
+    /// Pass `debug_file` and `debug_id` describing a specific module,
+    /// and `address`, a module-relative address, and get back
+    /// a symbol in that module that covers that address, or `None`.
+    ///
+    /// See [the module-level documentation][module] for an example.
+    ///
+    /// [module]: index.html
+    pub async fn get_symbol_at_address(
+        &self,
+        debug_file: &str,
+        debug_id: DebugId,
+        address: u64,
+    ) -> Option<String> {
+        let k = (debug_file, debug_id);
+        let mut frame = SimpleFrame::with_instruction(address);
+        self.fill_symbol(&k, &mut frame).await.ok()?;
+        frame.function
+    }
+
+    /// Fill symbol information in `frame` using the instruction address
+    /// from `frame`, and the module information from `module`. If you're not
+    /// using a minidump module, you can use [`SimpleModule`][simplemodule] and
+    /// [`SimpleFrame`][simpleframe].
+    ///
+    /// An Error indicates that no symbols could be found for the relevant
+    /// module.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # std::env::set_current_dir(env!("CARGO_MANIFEST_DIR"));
+    /// use std::str::FromStr;
+    /// use debugid::DebugId;
+    /// use breakpad_symbols::{SimpleSymbolSupplier,Symbolizer,SimpleFrame,SimpleModule};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     use std::path::PathBuf;
+    ///     let paths = vec!(PathBuf::from("../testdata/symbols/"));
+    ///     let supplier = SimpleSymbolSupplier::new(paths);
+    ///     let symbolizer = Symbolizer::new(supplier);
+    ///     let debug_id = DebugId::from_str("5A9832E5287241C1838ED98914E9B7FF1").unwrap();
+    ///     let m = SimpleModule::new("test_app.pdb", debug_id);
+    ///     let mut f = SimpleFrame::with_instruction(0x1010);
+    ///     let _ = symbolizer.fill_symbol(&m, &mut f).await;
+    ///     assert_eq!(f.function.unwrap(), "vswprintf");
+    ///     assert_eq!(f.source_file.unwrap(),
+    ///         r"c:\program files\microsoft visual studio 8\vc\include\swprintf.inl");
+    ///     assert_eq!(f.source_line.unwrap(), 51);
+    /// }
+    /// ```
+    ///
+    /// [simplemodule]: struct.SimpleModule.html
+    /// [simpleframe]: struct.SimpleFrame.html
+    pub async fn fill_symbol(
+        &self,
+        module: &(dyn Module + Sync),
+        frame: &mut (dyn FrameSymbolizer + Send),
+    ) -> Result<(), FillSymbolError> {
+        let cached_sym = self.get_symbols(module).await;
+        let sym = cached_sym
+            .get()
+            .unwrap()
+            .as_ref()
+            .map_err(|_| FillSymbolError {})?;
+        sym.fill_symbol(module, frame);
+        Ok(())
+    }
+
+    /// Collect various statistics on the symbols.
+    ///
+    /// Keys are the file name of the module (code_file's file name).
+    pub fn stats(&self) -> HashMap<String, SymbolStats> {
+        self.symbols
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, res)| {
+                let res = res.get().expect("Had uninitialized SymbolFile entry?");
+                let mut stats = SymbolStats::default();
+                match res {
+                    Ok(sym) => {
+                        stats.symbol_url = sym.url.clone();
+                        stats.loaded_symbols = true;
+                        stats.corrupt_symbols = false;
+                    }
+                    Err(SymbolError::NotFound) => {
+                        stats.loaded_symbols = false;
+                    }
+                    Err(SymbolError::MissingDebugFileOrId) => {
+                        stats.loaded_symbols = false;
+                    }
+                    Err(SymbolError::LoadError(_)) => {
+                        stats.loaded_symbols = false;
+                    }
+                    Err(SymbolError::ParseError(..)) => {
+                        stats.loaded_symbols = true;
+                        stats.corrupt_symbols = true;
+                    }
+                }
+                (leafname(&k.0).to_string(), stats)
+            })
+            .collect()
+    }
+
+    /// Tries to use CFI to walk the stack frame of the FrameWalker
+    /// using the symbols of the given Module. Output will be written
+    /// using the FrameWalker's `set_caller_*` APIs.
+    pub async fn walk_frame(
+        &self,
+        module: &(dyn Module + Sync),
+        walker: &mut (dyn FrameWalker + Send),
+    ) -> Option<()> {
+        let cached_sym = self.get_symbols(module).await;
+        let sym = cached_sym.get().unwrap().as_ref();
+        if let Ok(sym) = sym {
+            trace!("found symbols for address, searching for cfi entries");
+            sym.walk_frame(module, walker)
+        } else {
+            trace!("couldn't find symbols for address, cannot use cfi");
+            None
+        }
+    }
+
+    /// Gets the fully parsed SymbolFile for a given module (or an Error).
+    ///
+    /// This returns a CachedOperation which is guaranteed to already be resolved (lifetime stuff).
+    async fn get_symbols(
+        &self,
+        module: &(dyn Module + Sync),
+    ) -> CachedOperation<SymbolFile, SymbolError> {
+        // This clones an Arc<Once> that we will use to only do this operation once
+        let k = module_key(module);
+        let symbol_once = self.symbols.lock().unwrap().entry(k).or_default().clone();
+        symbol_once
+            .get_or_init(|| async {
+                trace!("locating symbols for module {}", module.code_file());
+                self.supplier.locate_symbols(module).await
+            })
+            .await;
+        symbol_once
+    }
+
+    /// Gets the path to a file for a given module (or an Error).
+    ///
+    /// This returns a CachedOperation which is guaranteed to already be resolved (lifetime stuff).
+    pub async fn get_file_path(
+        &self,
+        module: &(dyn Module + Sync),
+        file_kind: FileKind,
+    ) -> Result<PathBuf, FileError> {
+        self.supplier.locate_file(module, file_kind).await
+    }
+}
+
+#[async_trait]
+impl SymbolProvider for Symbolizer {
+    async fn fill_symbol(
+        &self,
+        module: &(dyn Module + Sync),
+        frame: &mut (dyn FrameSymbolizer + Send),
+    ) -> Result<(), FillSymbolError> {
+        self.fill_symbol(module, frame).await
+    }
+    async fn walk_frame(
+        &self,
+        module: &(dyn Module + Sync),
+        walker: &mut (dyn FrameWalker + Send),
+    ) -> Option<()> {
+        self.walk_frame(module, walker).await
+    }
+    async fn get_file_path(
+        &self,
+        module: &(dyn Module + Sync),
+        file_kind: FileKind,
+    ) -> Result<PathBuf, FileError> {
+        self.get_file_path(module, file_kind).await
+    }
+    fn stats(&self) -> HashMap<String, SymbolStats> {
+        self.stats()
+    }
+}

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -12,18 +12,8 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "rust-minidump/rust-minidump" }
 
-[features]
-default = []
-# Allows retrieval of symbol files via HTTP
-http = ["breakpad-symbols/http"]
-# Allows construction of symbol files from native binaries
-dump_syms = ["breakpad-symbols/dump_syms", "http"]
-# Allows retrieval of CABed symbol files from mozilla servers
-mozilla_cab_symbols = ["breakpad-symbols/mozilla_cab_symbols"]
-
 [dependencies]
 async-trait = "0.1.51"
-breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols" }
 debugid = "0.8.0"
 tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.3"
@@ -35,6 +25,7 @@ serde_json = "1.0"
 thiserror = "1.0.30"
 
 [dev-dependencies]
+breakpad-symbols = { path = "../breakpad-symbols" }
 doc-comment = "0.3.3"
 minidump-synth = { path = "../minidump-synth" }
 test-assembler = "0.1.6"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -13,11 +13,7 @@ edition = "2018"
 travis-ci = { repository = "rust-minidump/rust-minidump" }
 
 [features]
-default = ["breakpad-syms"]
-# Use the `breakpad-symbols` crate for symbolizing and cfi evaluation
-breakpad-syms = ["breakpad-symbols"]
-# Use the `symbolic` crate for symbolizing and cfi evaluation (TODO)
-symbolic-syms = []
+default = []
 # Allows retrieval of symbol files via HTTP
 http = ["breakpad-symbols/http"]
 # Allows construction of symbol files from native binaries
@@ -27,7 +23,7 @@ mozilla_cab_symbols = ["breakpad-symbols/mozilla_cab_symbols"]
 
 [dependencies]
 async-trait = "0.1.51"
-breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols", optional = true }
+breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols" }
 debugid = "0.8.0"
 tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.3"

--- a/minidump-processor/README.md
+++ b/minidump-processor/README.md
@@ -16,15 +16,16 @@ For a CLI application that wraps this library, see [minidump-stackwalk](https://
 If you do need to use minidump-processor as a library, we still recommend using the stabilized JSON output. The native APIs work fine and contain all the same information, we just haven't stabilized them yet, so updates are more likely to result in breakage. Here is a minimal example which gets the JSON output (and parses it with serde_json):
 
 ```rust
+use breakpad_symbols::http_symbol_supplier;
 use minidump::Minidump;
-use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
+use minidump_processor::{ProcessorOptions, Symbolizer};
 use serde_json::Value;
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     // Read the minidump
     let dump = Minidump::read_path("../testdata/test.dmp").map_err(|_| ())?;
- 
+
     // Configure the symbolizer and processor
     let symbols_urls = vec![String::from("https://symbols.totallyrealwebsite.org")];
     let symbols_paths = vec![];
@@ -32,7 +33,7 @@ async fn main() -> Result<(), ()> {
     symbols_cache.push("minidump-cache");
     let symbols_tmp = std::env::temp_dir();
     let timeout = std::time::Duration::from_secs(1000);
- 
+
     // Use ProcessorOptions for detailed configuration
     let options = ProcessorOptions::default();
 
@@ -44,7 +45,7 @@ async fn main() -> Result<(), ()> {
         symbols_tmp,
         timeout,
     ));
- 
+
     let state = minidump_processor::process_minidump_with_options(&dump, &provider, options)
         .await
         .map_err(|_| ())?;

--- a/minidump-processor/src/lib.rs
+++ b/minidump-processor/src/lib.rs
@@ -17,8 +17,9 @@
 //! (and parses it with serde_json):
 //!  
 //! ```rust
+//! use breakpad_symbols::http_symbol_supplier;
 //! use minidump::Minidump;
-//! use minidump_processor::{http_symbol_supplier, ProcessorOptions, Symbolizer};
+//! use minidump_processor::{ProcessorOptions, Symbolizer};
 //! use serde_json::Value;
 //!  
 //! #[tokio::main]

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -1,14 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::format::CONTEXT_AMD64;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 struct TestFixture {
     pub raw: CONTEXT_AMD64,

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use breakpad_symbols::string_symbol_supplier;
+use breakpad_symbols::{string_symbol_supplier, Symbolizer};
 use minidump::format::CONTEXT_AMD64;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
@@ -11,7 +11,7 @@ use test_assembler::*;
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{Symbolizer, SystemInfo};
+use crate::SystemInfo;
 
 struct TestFixture {
     pub raw: CONTEXT_AMD64,

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -6,14 +6,14 @@
 
 use std::collections::HashMap;
 
-use breakpad_symbols::string_symbol_supplier;
+use breakpad_symbols::{string_symbol_supplier, Symbolizer};
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use test_assembler::*;
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{Symbolizer, SystemInfo};
+use crate::SystemInfo;
 
 type Context = minidump::format::CONTEXT_ARM64;
 

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -4,13 +4,16 @@
 // NOTE: we don't bother testing arm64_old, it should have identical code at
 // all times!
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 type Context = minidump::format::CONTEXT_ARM64;
 

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -1,14 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::format::CONTEXT_ARM;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 struct TestFixture {
     pub raw: CONTEXT_ARM,

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use breakpad_symbols::string_symbol_supplier;
+use breakpad_symbols::{string_symbol_supplier, Symbolizer};
 use minidump::format::CONTEXT_ARM;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
@@ -11,7 +11,7 @@ use test_assembler::*;
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{Symbolizer, SystemInfo};
+use crate::SystemInfo;
 
 struct TestFixture {
     pub raw: CONTEXT_ARM,

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use breakpad_symbols::string_symbol_supplier;
+use breakpad_symbols::{string_symbol_supplier, Symbolizer};
 use minidump::format::CONTEXT_X86;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
@@ -11,7 +11,7 @@ use test_assembler::*;
 
 use crate::process_state::*;
 use crate::stackwalker::walk_stack;
-use crate::{Symbolizer, SystemInfo};
+use crate::SystemInfo;
 
 struct TestFixture {
     pub raw: CONTEXT_X86,

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -1,14 +1,17 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
-use crate::process_state::*;
-use crate::stackwalker::walk_stack;
-use crate::{string_symbol_supplier, Symbolizer, SystemInfo};
+use std::collections::HashMap;
+
+use breakpad_symbols::string_symbol_supplier;
 use minidump::format::CONTEXT_X86;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
-use std::collections::HashMap;
 use test_assembler::*;
+
+use crate::process_state::*;
+use crate::stackwalker::walk_stack;
+use crate::{Symbolizer, SystemInfo};
 
 struct TestFixture {
     pub raw: CONTEXT_X86,

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -1,12 +1,5 @@
 //! This module defines the interface between minidump-processor and its [Symbolizer][].
 //!
-//! There can only be one [Symbolizer][], and this is configured by minidump-processor's Cargo
-//! feature flags. The currently defined Symbolizers are:
-//!
-//! * breakpad_symbols -- feature: breakpad-syms (currently the default)
-//! * symbolic -- feature: symbolic-syms (not yet implemented, but compiles)
-//!
-//!
 //! minidump-processor and the [Symbolizer][] communicate using a series of traits. The symbolizer
 //! must provide implementations of these traits:
 //!

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -96,10 +96,16 @@
 //! ```
 //!
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use minidump::Module;
-use std::{collections::HashMap, path::PathBuf};
-pub use symbols_shim::*;
+
+pub use breakpad_symbols::{
+    FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolError, SymbolFile,
+    SymbolStats, SymbolSupplier, Symbolizer,
+};
 
 #[async_trait]
 pub trait SymbolProvider {
@@ -193,385 +199,84 @@ impl SymbolProvider for MultiSymbolProvider {
     }
 }
 
-#[cfg(feature = "breakpad-syms")]
-mod symbols_shim {
-    use super::SymbolProvider;
-    use async_trait::async_trait;
-    pub use breakpad_symbols::{
-        FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolError,
-        SymbolFile, SymbolStats, SymbolSupplier, Symbolizer,
-    };
-    use minidump::Module;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-
-    #[async_trait]
-    impl SymbolProvider for Symbolizer {
-        async fn fill_symbol(
-            &self,
-            module: &(dyn Module + Sync),
-            frame: &mut (dyn FrameSymbolizer + Send),
-        ) -> Result<(), FillSymbolError> {
-            self.fill_symbol(module, frame).await
-        }
-        async fn walk_frame(
-            &self,
-            module: &(dyn Module + Sync),
-            walker: &mut (dyn FrameWalker + Send),
-        ) -> Option<()> {
-            self.walk_frame(module, walker).await
-        }
-        async fn get_file_path(
-            &self,
-            module: &(dyn Module + Sync),
-            file_kind: FileKind,
-        ) -> Result<PathBuf, FileError> {
-            self.get_file_path(module, file_kind).await
-        }
-        fn stats(&self) -> HashMap<String, SymbolStats> {
-            self.stats()
-        }
+#[async_trait]
+impl SymbolProvider for Symbolizer {
+    async fn fill_symbol(
+        &self,
+        module: &(dyn Module + Sync),
+        frame: &mut (dyn FrameSymbolizer + Send),
+    ) -> Result<(), FillSymbolError> {
+        self.fill_symbol(module, frame).await
     }
-
-    /// Gets a SymbolSupplier that looks up symbols by path or with urls.
-    ///
-    /// * `symbols_paths` is a list of paths to check for symbol files. Paths
-    ///   are searched in order until one returns a payload. If none do, then
-    ///   urls are used.
-    ///
-    /// * `symbols_urls` is a list of "base urls" that should all point to Tecken
-    ///   servers. urls are queried in order until one returns a payload. If none
-    ///   do, then it's an error.
-    ///
-    /// * `symbols_cache` is a directory where an on-disk cache should be located.
-    ///   This should be assumed to be a "temp" directory that another process
-    ///   you don't control is garbage-collecting old files from (to provide an LRU cache).
-    ///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
-    ///
-    /// * `symbols_tmp` is a directory where symbol files should be downloaded to
-    ///   before atomically swapping them into the cache. Has the same "temp"
-    ///   assumptions as symbols_cache.
-    ///
-    /// * `timeout` a maximum time limit for a symbol file download. This
-    ///   is primarily defined to avoid getting stuck on buggy infinite downloads.
-    ///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
-    ///   the event of a timeout, the supplier may still try to parse the truncated
-    ///   download.
-    #[cfg(feature = "http")]
-    pub fn http_symbol_supplier(
-        symbol_paths: Vec<PathBuf>,
-        symbol_urls: Vec<String>,
-        symbols_cache: PathBuf,
-        symbols_tmp: PathBuf,
-        timeout: std::time::Duration,
-    ) -> impl SymbolSupplier {
-        breakpad_symbols::HttpSymbolSupplier::new(
-            symbol_urls,
-            symbols_cache,
-            symbols_tmp,
-            symbol_paths,
-            timeout,
-        )
+    async fn walk_frame(
+        &self,
+        module: &(dyn Module + Sync),
+        walker: &mut (dyn FrameWalker + Send),
+    ) -> Option<()> {
+        self.walk_frame(module, walker).await
     }
-
-    /// Gets a SymbolSupplier that looks up symbols by path.
-    ///
-    /// Paths are queried in order until one returns a payload.
-    pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
-        breakpad_symbols::SimpleSymbolSupplier::new(symbol_paths)
+    async fn get_file_path(
+        &self,
+        module: &(dyn Module + Sync),
+        file_kind: FileKind,
+    ) -> Result<PathBuf, FileError> {
+        self.get_file_path(module, file_kind).await
     }
-
-    /// Gets a mock SymbolSupplier that just maps module names
-    /// to a string containing an entire breakpad .sym file, for tests.
-    pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
-        breakpad_symbols::StringSymbolSupplier::new(modules)
+    fn stats(&self) -> HashMap<String, SymbolStats> {
+        self.stats()
     }
 }
 
-#[cfg(all(feature = "symbolic-syms", not(feature = "breakpad-syms")))]
-mod symbols_shim {
-    #![allow(dead_code)]
+/// Gets a SymbolSupplier that looks up symbols by path or with urls.
+///
+/// * `symbols_paths` is a list of paths to check for symbol files. Paths
+///   are searched in order until one returns a payload. If none do, then
+///   urls are used.
+///
+/// * `symbols_urls` is a list of "base urls" that should all point to Tecken
+///   servers. urls are queried in order until one returns a payload. If none
+///   do, then it's an error.
+///
+/// * `symbols_cache` is a directory where an on-disk cache should be located.
+///   This should be assumed to be a "temp" directory that another process
+///   you don't control is garbage-collecting old files from (to provide an LRU cache).
+///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
+///
+/// * `symbols_tmp` is a directory where symbol files should be downloaded to
+///   before atomically swapping them into the cache. Has the same "temp"
+///   assumptions as symbols_cache.
+///
+/// * `timeout` a maximum time limit for a symbol file download. This
+///   is primarily defined to avoid getting stuck on buggy infinite downloads.
+///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
+///   the event of a timeout, the supplier may still try to parse the truncated
+///   download.
+#[cfg(feature = "http")]
+pub fn http_symbol_supplier(
+    symbol_paths: Vec<PathBuf>,
+    symbol_urls: Vec<String>,
+    symbols_cache: PathBuf,
+    symbols_tmp: PathBuf,
+    timeout: std::time::Duration,
+) -> impl SymbolSupplier {
+    breakpad_symbols::HttpSymbolSupplier::new(
+        symbol_urls,
+        symbols_cache,
+        symbols_tmp,
+        symbol_paths,
+        timeout,
+    )
+}
 
-    use super::SymbolProvider;
-    use async_trait::async_trait;
-    use minidump::Module;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-    use std::time::Duration;
+/// Gets a SymbolSupplier that looks up symbols by path.
+///
+/// Paths are queried in order until one returns a payload.
+pub fn simple_symbol_supplier(symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
+    breakpad_symbols::SimpleSymbolSupplier::new(symbol_paths)
+}
 
-    // Import symbolic here
-
-    /// A trait for things that can locate symbols for a given module.
-    #[async_trait]
-    pub trait SymbolSupplier {
-        /// Locate and load a symbol file for `module`.
-        ///
-        /// Implementations may use any strategy for locating and loading
-        /// symbols.
-        async fn locate_symbols(
-            &mut self,
-            module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError>;
-
-        /// Locate a specific file associated with a `module`
-        ///
-        /// Implementations may use any strategy for locating and loading
-        /// symbols.
-        async fn locate_file(
-            &self,
-            module: &(dyn Module + Sync),
-            file_kind: FileKind,
-        ) -> Result<PathBuf, FileError>;
-    }
-
-    /// A trait for setting symbol information on something like a stack frame.
-    pub trait FrameSymbolizer {
-        /// Get the program counter value for this frame.
-        fn get_instruction(&self) -> u64;
-        /// Set the name, base address, and paramter size of the function in
-        // which this frame is executing.
-        fn set_function(&mut self, name: &str, base: u64, parameter_size: u32);
-        /// Set the source file and (1-based) line number this frame represents.
-        fn set_source_file(&mut self, file: &str, line: u32, base: u64);
-    }
-
-    pub trait FrameWalker {
-        /// Get the instruction address that we're trying to unwind from.
-        fn get_instruction(&self) -> u64;
-        /// Get the number of bytes the callee's callee's parameters take up
-        /// on the stack (or 0 if unknown/invalid). This is needed for
-        /// STACK WIN unwinding.
-        fn get_grand_callee_parameter_size(&self) -> u32;
-        /// Get a register-sized value stored at this address.
-        fn get_register_at_address(&self, address: u64) -> Option<u64>;
-        /// Get the value of a register from the callee's frame.
-        fn get_callee_register(&self, name: &str) -> Option<u64>;
-        /// Set the value of a register for the caller's frame.
-        fn set_caller_register(&mut self, name: &str, val: u64) -> Option<()>;
-        /// Explicitly mark one of the caller's registers as invalid.
-        fn clear_caller_register(&mut self, name: &str);
-        /// Set whatever registers in the caller should be set based on the cfa (e.g. rsp).
-        fn set_cfa(&mut self, val: u64) -> Option<()>;
-        /// Set whatever registers in the caller should be set based on the return address (e.g. rip).
-        fn set_ra(&mut self, val: u64) -> Option<()>;
-    }
-
-    /// Symbolicate stack frames.
-    ///
-    /// A `Symbolizer` manages loading symbols and looking up symbols in them
-    /// including caching so that symbols for a given module are only loaded once.
-    ///
-    /// Call [`Symbolizer::new`][new] to instantiate a `Symbolizer`. A Symbolizer
-    /// requires a [`SymbolSupplier`][supplier] to locate symbols. If you have
-    /// symbols on disk in the [customary directory layout][dirlayout], a
-    /// [`SimpleSymbolSupplier`][simple] will work.
-    ///
-    /// Use [`get_symbol_at_address`][get_symbol] or [`fill_symbol`][fill_symbol] to
-    /// do symbol lookup.
-    ///
-    /// [new]: struct.Symbolizer.html#method.new
-    /// [supplier]: trait.SymbolSupplier.html
-    /// [dirlayout]: fn.relative_symbol_path.html
-    /// [simple]: struct.SimpleSymbolSupplier.html
-    /// [get_symbol]: struct.Symbolizer.html#method.get_symbol_at_address
-    /// [fill_symbol]: struct.Symbolizer.html#method.fill_symbol
-    pub struct Symbolizer {
-        /// Symbol supplier for locating symbols.
-        supplier: Box<dyn SymbolSupplier + 'static + Send + Sync>,
-    }
-
-    impl Symbolizer {
-        /// Create a `Symbolizer` that uses `supplier` to locate symbols.
-        pub fn new<T: SymbolSupplier + 'static + Send + Sync>(supplier: T) -> Symbolizer {
-            Symbolizer {
-                supplier: Box::new(supplier),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl SymbolProvider for Symbolizer {
-        async fn fill_symbol(
-            &self,
-            _module: &(dyn Module + Sync),
-            _frame: &mut (dyn FrameSymbolizer + Send),
-        ) -> Result<(), FillSymbolError> {
-            unimplemented!()
-        }
-        async fn walk_frame(
-            &self,
-            _module: &(dyn Module + Sync),
-            _walker: &mut (dyn FrameWalker + Send),
-        ) -> Option<()> {
-            unimplemented!()
-        }
-        fn stats(&self) -> HashMap<String, SymbolStats> {
-            unimplemented!()
-        }
-        async fn get_file_path(
-            &self,
-            module: &(dyn Module + Sync),
-            file_kind: FileKind,
-        ) -> Result<PathBuf, FileError> {
-            unimplemented!()
-        }
-    }
-
-    /// Gets a SymbolSupplier that looks up symbols by path or with urls.
-    ///
-    /// * `symbols_paths` is a list of paths to check for symbol files. Paths
-    ///   are searched in order until one returns a payload. If none do, then
-    ///   urls are used.
-    ///
-    /// * `symbols_urls` is a list of "base urls" that should all point to Tecken
-    ///   servers. urls are queried in order until one returns a payload. If none
-    ///   do, then it's an error.
-    ///
-    /// * `symbols_cache` is a directory where an on-disk cache should be located.
-    ///   This should be assumed to be a "temp" directory that another process
-    ///   you don't control is garbage-collecting old files from (to provide an LRU cache).
-    ///   The cache is queried before paths and urls (otherwise it wouldn't be much of a cache).
-    ///
-    /// * `symbols_tmp` is a directory where symbol files should be downloaded to
-    ///   before atomically swapping them into the cache. Has the same "temp"
-    ///   assumptions as symbols_cache.
-    ///
-    /// * `timeout` a maximum time limit (in seconds) for a symbol file download. This
-    ///   is primarily defined to avoid getting stuck on buggy infinite downloads.
-    ///   As of this writing, minidump-stackwalk defaults this to 1000 seconds. In
-    ///   the event of a timeout, the supplier may still try to parse the truncated
-    ///   download.
-    pub fn http_symbol_supplier(
-        _symbol_paths: Vec<PathBuf>,
-        _symbol_urls: Vec<String>,
-        _symbols_cache: PathBuf,
-        _symbols_tmp: PathBuf,
-        _timeout: Duration,
-    ) -> impl SymbolSupplier {
-        HttpSymbolSupplier {}
-    }
-
-    /// Gets a SymbolSupplier that looks up symbols by path.
-    ///
-    /// Paths are queried in order until one returns a payload.
-    pub fn simple_symbol_supplier(_symbol_paths: Vec<PathBuf>) -> impl SymbolSupplier {
-        SimpleSymbolSupplier {}
-    }
-
-    /// Gets a mock SymbolSupplier that just maps module names
-    /// to a string containing an entire breakpad .sym file, for tests.
-    pub fn string_symbol_supplier(_modules: HashMap<String, String>) -> impl SymbolSupplier {
-        StringSymbolSupplier {}
-    }
-
-    /// A type of file related to a module that you might want downloaded.
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub enum FileKind {
-        /// A Breakpad symbol (.sym) file
-        BreakpadSym,
-        /// The native binary of a module ("code file") (.exe/.dll/.so/.dylib...)
-        Binary,
-        /// Extra debuginfo for a module ("debug file") (.pdb/...?)
-        ExtraDebugInfo,
-    }
-
-    /// Possible results of locating symbols for a module.
-    ///
-    /// Because symbols may be found from different sources, symbol providers
-    /// are usually configured to "cascade" into the next one whenever they report
-    /// `NotFound`.
-    ///
-    /// Cascading currently assumes that if any provider finds symbols for
-    /// a module, all other providers will find the same symbols (if any).
-    /// Therefore cascading will not be applied if a LoadError or ParseError
-    /// occurs (because presumably, all the other sources will also fail to
-    /// load/parse.)
-    ///
-    /// In theory we could do some interesting things where we attempt to
-    /// be more robust and actually merge together the symbols from multiple
-    /// sources, but that would make it difficult to cache symbol files, and
-    /// would rarely actually improve results.
-    ///
-    /// Since symbol files can be on the order of a gigabyte(!) and downloaded
-    /// from the network, aggressive caching is pretty important. The current
-    /// approach is a nice balance of simple and effective.
-    #[derive(Debug)]
-    pub enum SymbolError {
-        /// Symbol file could not be found.
-        ///
-        /// In this case other symbol providers may still be able to find it!
-        NotFound,
-        /// Symbol file could not be loaded into memory.
-        LoadError,
-        /// Symbol file was too corrupt to be parsed at all.
-        ///
-        /// Because symbol files are pretty modular, many corruptions/ambiguities
-        /// can be either repaired or discarded at a fairly granular level
-        /// (e.g. a bad STACK WIN line can be discarded without affecting anything
-        /// else). But sometimes we can't make any sense of the symbol file, and
-        /// you find yourself here.
-        ParseError,
-    }
-
-    #[derive(Clone, Debug, thiserror::Error)]
-    pub enum FileError {
-        #[error("file not found")]
-        NotFound,
-    }
-
-    #[derive(Debug)]
-    pub struct FillSymbolError {}
-
-    // Whatever representation you want, rust-minidump won't look at it.
-    pub struct SymbolFile {}
-
-    /// Statistics on the symbols of a module.
-    #[derive(Default, Debug)]
-    pub struct SymbolStats {
-        /// If the module's symbols were downloaded, this is the url used.
-        pub symbol_url: Option<String>,
-        /// If the symbols were found and loaded into memory.
-        pub loaded_symbols: bool,
-        /// If we tried to parse the symbols, but failed.
-        pub corrupt_symbols: bool,
-    }
-
-    // These suppliers are entriely private to the implementation, so do whatever you
-    // want with them.
-
-    struct HttpSymbolSupplier {}
-
-    struct SimpleSymbolSupplier {}
-
-    struct StringSymbolSupplier {}
-
-    #[async_trait]
-    impl SymbolSupplier for HttpSymbolSupplier {
-        async fn locate_symbols(
-            &mut self,
-            _module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError> {
-            unimplemented!()
-        }
-    }
-
-    #[async_trait]
-    impl SymbolSupplier for SimpleSymbolSupplier {
-        async fn locate_symbols(
-            &mut self,
-            _module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError> {
-            unimplemented!()
-        }
-    }
-
-    #[async_trait]
-    impl SymbolSupplier for StringSymbolSupplier {
-        async fn locate_symbols(
-            &mut self,
-            _module: &(dyn Module + Sync),
-        ) -> Result<SymbolFile, SymbolError> {
-            unimplemented!()
-        }
-    }
+/// Gets a mock SymbolSupplier that just maps module names
+/// to a string containing an entire breakpad .sym file, for tests.
+pub fn string_symbol_supplier(modules: HashMap<String, String>) -> impl SymbolSupplier {
+    breakpad_symbols::StringSymbolSupplier::new(modules)
 }

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -3,12 +3,12 @@
 
 use std::path::{Path, PathBuf};
 
-use breakpad_symbols::simple_symbol_supplier;
+use breakpad_symbols::{simple_symbol_supplier, Symbolizer};
 use minidump::system_info::{Cpu, Os};
 use minidump::{
     Error, Minidump, MinidumpContext, MinidumpContextValidity, MinidumpRawContext, Module,
 };
-use minidump_processor::{CallStackInfo, FrameTrust, LinuxStandardBase, ProcessState, Symbolizer};
+use minidump_processor::{CallStackInfo, FrameTrust, LinuxStandardBase, ProcessState};
 use minidump_synth::*;
 use test_assembler::*;
 

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -1,15 +1,14 @@
 // Copyright 2015 Ted Mielczarek. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 
+use std::path::{Path, PathBuf};
+
+use breakpad_symbols::simple_symbol_supplier;
 use minidump::system_info::{Cpu, Os};
 use minidump::{
     Error, Minidump, MinidumpContext, MinidumpContextValidity, MinidumpRawContext, Module,
 };
-use minidump_processor::{
-    simple_symbol_supplier, CallStackInfo, FrameTrust, LinuxStandardBase, ProcessState, Symbolizer,
-};
-use std::path::{Path, PathBuf};
-
+use minidump_processor::{CallStackInfo, FrameTrust, LinuxStandardBase, ProcessState, Symbolizer};
 use minidump_synth::*;
 use test_assembler::*;
 

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -21,6 +21,7 @@ dump_syms = ["minidump-processor/dump_syms"]
 mozilla_cab_symbols = ["minidump-processor/mozilla_cab_symbols"]
 
 [dependencies]
+breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols" }
 clap = { version = "3.1", features = ["cargo", "wrap_help", "derive"] }
 minidump = { version = "0.11.0", path = "../minidump" }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -16,18 +16,16 @@ travis-ci = { repository = "rust-minidump/rust-minidump" }
 
 [features]
 # Allows construction of symbol files from native binaries
-dump_syms = ["minidump-processor/dump_syms"]
+dump_syms = ["breakpad-symbols/dump_syms"]
 # Allows retrieval of CABed symbol files from mozilla servers
-mozilla_cab_symbols = ["minidump-processor/mozilla_cab_symbols"]
+mozilla_cab_symbols = ["breakpad-symbols/mozilla_cab_symbols"]
 
 [dependencies]
-breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols" }
+breakpad-symbols = { version = "0.11.0", path = "../breakpad-symbols", features = ["http"] }
 clap = { version = "3.1", features = ["cargo", "wrap_help", "derive"] }
 minidump = { version = "0.11.0", path = "../minidump" }
 minidump-common = { version = "0.11.0", path = "../minidump-common" }
-minidump-processor = { version = "0.11.0", path = "../minidump-processor", features = [
-    "http",
-] }
+minidump-processor = { version = "0.11.0", path = "../minidump-processor" }
 tokio = { version = "1.12.0", features = ["full"] }
 tracing = { version = "0.1.34", features = ["log"] }
 tracing-subscriber = "0.3.14"

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -8,9 +8,11 @@ use std::panic;
 use std::time::Duration;
 use std::{boxed::Box, path::PathBuf};
 
-use breakpad_symbols::{http_symbol_supplier, simple_symbol_supplier};
+use breakpad_symbols::{
+    http_symbol_supplier, simple_symbol_supplier, MultiSymbolProvider, Symbolizer,
+};
 use minidump::*;
-use minidump_processor::{MultiSymbolProvider, ProcessorOptions, Symbolizer};
+use minidump_processor::ProcessorOptions;
 
 use clap::{AppSettings, ArgGroup, CommandFactory, Parser};
 use tracing::error;

--- a/minidump-stackwalk/src/main.rs
+++ b/minidump-stackwalk/src/main.rs
@@ -8,10 +8,9 @@ use std::panic;
 use std::time::Duration;
 use std::{boxed::Box, path::PathBuf};
 
+use breakpad_symbols::{http_symbol_supplier, simple_symbol_supplier};
 use minidump::*;
-use minidump_processor::{
-    http_symbol_supplier, simple_symbol_supplier, MultiSymbolProvider, ProcessorOptions, Symbolizer,
-};
+use minidump_processor::{MultiSymbolProvider, ProcessorOptions, Symbolizer};
 
 use clap::{AppSettings, ArgGroup, CommandFactory, Parser};
 use tracing::error;


### PR DESCRIPTION
Ideally the processor should not care about the concrete SymbolProvider,
and breakpad-symbols should only implement the required traits.

This currently fails because the unit tests pull in breakpad-symbols and that creates a circular dependency problem which manifests itself as a traits mismatch.

Builds on top of #614 