### PR TITLE
Fix code_identifier for iOS

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -1028,7 +1028,7 @@ impl Module for MinidumpModule {
 
     fn code_identifier(&self) -> Option<CodeId> {
         match self.codeview_info {
-            Some(CodeView::Pdb70(ref raw)) if self.os == Os::MacOs => {
+            Some(CodeView::Pdb70(ref raw)) if matches!(self.os, Os::MacOs | Os::Ios) => {
                 // MacOs uses PDB70 instead of its own dedicated format.
                 // See the following issue for a potential MacOs-specific format:
                 // https://github.com/rust-minidump/rust-minidump/issues/455


### PR DESCRIPTION
Platform detection in `code_identifier` erroneously only checked for `Os::MacOs` and let `Os::Ios` fall through to the windows case.