### PR TITLE
feat: http-symbol-supplier configurability

### DIFF
--- a/breakpad-symbols/src/http.rs
+++ b/breakpad-symbols/src/http.rs
@@ -12,10 +12,205 @@ use tracing::{debug, trace, warn};
 /// A key that uniquely identifies a File associated with a module
 type FileKey = (ModuleKey, FileKind);
 
+/// Various options for [`HttpSymbolSupplier`]
+///
+/// # Recipes
+///
+/// ## Mozilla HTTP Symbol Files
+///
+/// This is the "standard" configuration for someone fully bought into the
+/// breakpad/rust-minidump ecosystem. Substitute in the URL for your own
+/// symbol server.
+///
+/// ```
+/// HttpSymbolSupplierOptions {
+///     urls: vec!["https://symbols.mozilla.org/".to_owned()],
+///     cache: Some(std::env::tempdir().join("minidump-symbols")),
+///     tmp: Some(std::env::tempdir())
+/// }
+/// ```
+///
+///
+/// ## Microsoft HTTP Native Symbols
+///
+/// This is the configuration that emulates the experience of using official
+/// Microsoft minidump tooling like windbg.
+///
+/// ```
+/// HttpSymbolSupplierOptions {
+///     urls: vec!["https://msdl.microsoft.com/download/symbols/".to_owned()],
+///     cache: Some(std::env::tempdir().join("minidump-symbols")),
+///     tmp: Some(std::env::tempdir()),
+///     fetch_syms: false,
+///     fetch_native_binaries: true,
+/// }
+/// ```
+///
+///
+/// ## Local Development
+///
+/// This configuration works when analyzing minidumps on the same machine
+/// the crash was produced on. Should work especially well if the crashed
+/// program was invoked with `cargo run`.
+///
+/// ```
+/// HttpSymbolSupplierOptions {
+///     cache: Some(std::env::tempdir().join("minidump-symbols")),
+///     tmp: Some(std::env::tempdir()),
+///     use_minidump_paths: true,
+/// }
+/// ```
+///
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct HttpSymbolSupplierOptions {
+    /// URLs to symbol servers, to try in order.
+    ///
+    /// Defaults to `vec![]`, meaning now URLs will be queried.
+    ///
+    /// When looking for symbols for a module, we will first look for breakpad symbols,
+    /// and then native symbols (codefile and debugfile). These queries may be launched
+    /// in parallel, but the if multiple URLs come back with a response, the tie will
+    /// be broken by order.
+    ///
+    /// We may also append some `?` parameters to the end of a url to help the symbol server
+    /// log symbols that it was missing in a way that can be acted upon, since the e.g.
+    /// a `sym` query doesn't provide necessary info about the codefile.
+    ///
+    /// Many of these details are configurable by other options in this struct.
+    ///
+    /// The path schema is as follows (see also the example queries below):
+    ///
+    /// * For syms: `DEBUG_FILE/DEBUG_ID/DEBUG_FILE.sym`
+    /// * For codefiles: `CODE_FILE/CODE_ID/CODE_FILE`
+    /// * For debugfiles: `DEBUG_FILE/DEBUG_ID/DEBUG_FILE`
+    ///
+    /// Example input URLs:
+    ///
+    /// * `https://symbols.mozilla.org/`
+    /// * `https://msdl.microsoft.com/download/symbols/`
+    ///
+    /// Example queries:
+    ///
+    /// * sym: `https://symbols.mozilla.org/DWrite.pdb/c10250ffba478e770798871932c7d8c51/DWrite.sym`
+    /// * debugfile: `https://msdl.microsoft.com/download/symbols/DWrite.pdb/c10250ffba478e770798871932c7d8c51/DWrite.pdb`
+    /// * codefile: `https://msdl.microsoft.com/download/symbols/DWrite.dll/29a9e8ad27f000/DWrite.dll`
+    pub urls: Vec<String>,
+    /// A base path to build a local symbol cache in.
+    ///
+    /// Defaults to `None`, but we highly recommend setting it!
+    ///
+    /// If this is None, we will only ever store loaded/computed symbols in memory
+    /// (to the best of our ability, unfortunately every feature that relies on
+    /// the `dump_syms` feature currently hard-requires the cache. We will emit
+    /// warnings if you disable cache/tmp with those features enabled.)
+    ///
+    /// If this is Some, then we will download symbols to an anonymous file
+    /// in the directory specified by the `tmp` option, and then "atomically"
+    /// rename them into their final location in the cache.
+    ///
+    /// The directory structure of the cache is identical to the one used for
+    /// `urls`, (so if you hosted the cache with a static file server and passed
+    /// it to `urls`, that would work).
+    ///
+    /// `cache` is queried before `urls`, so if we ever get something weird from
+    /// a url, it may stick around for all eternity, until the cache entry is removed.
+    ///
+    /// We don't ever garbage-collect our cache, and
+    /// just assume a monitor program handles this for us (which is ideally how
+    /// system temp dirs should automatically work if you're running out of space).
+    pub cache: Option<PathBuf>,
+    /// A directory for any temporary files that we need when downloading/computing
+    /// symbols. If this isn't set and we still need it, we will panic.
+    ///
+    /// Defaults to `Some(std::env::temp_dir())`.
+    ///
+    /// If you set `cache` we recommend setting this as well, as cache relies on
+    /// renaming files from this directory, and that doesn't work if they're on
+    /// different file systems (and some systems put /tmp/ on a separate filesystem)!
+    pub tmp: Option<PathBuf>,
+    /// Local paths to search for .sym files.
+    ///
+    /// Defaults to `vec![]`, meaning no paths will be queried.
+    ///
+    /// The structure of these dirs should be the same as `cache`.
+    /// Local results will be preferred over all other results,
+    /// and if there are multiple local results, the first one will be preferred.
+    pub local_paths: Vec<PathBuf>,
+    /// A timeout to use for http requests.
+    ///
+    /// Defaults to 1000 seconds.
+    pub timeout: Duration,
+    /// Whether to query urls for .sym files.
+    ///
+    /// Defaults to `true`.
+    ///
+    /// This mode works with "fake" Microsoft Symbol Servers like Tecken,
+    /// and is the mode that breakpad-symbols was designed for. These files
+    /// are generally significantly smaller than a codefile or debugfile,
+    /// where symbols natively reside.
+    pub fetch_syms: bool,
+    /// Whether to query urls for native codefiles and debugfiles.
+    ///
+    /// Currently defaults to `cfg!(feature = dump_syms)` (experimental).
+    ///
+    /// Setting this to `true` will do nothing if the `dump_syms` feature isn't also enabled.
+    ///
+    /// This mode works with "real" Microsoft Symbol Servers, and is experimental.
+    pub fetch_native_binaries: bool,
+    /// Whether to try to get symbols from the *actual* codefile and debugfile paths
+    /// on the current system.
+    ///
+    /// Currently defaults to `false` (experimental).
+    ///
+    /// Setting this to `true` will do nothing if the `dump_syms` feature isn't also enabled.
+    ///
+    /// The actual codefile and debugfile entries in a minidump are actually complete paths
+    /// from either the machine where the program was running, or the machine where the build
+    /// was performed. Either way, this means processing a minidump on the same machine
+    /// that the crash occured on can yield some symbols at those paths. This works especially
+    /// well for local development where "build machine" and "run machine" are the same, and
+    /// the executable is still in the build dir with ALL the debuginfo the compiler emitted!
+    ///
+    /// If `cache` is set, we *may* place a `sym` in it to optimize subsequent runs.
+    pub use_minidump_paths: bool,
+    /// Whether to append extra `?` parameters to http requests to symbol servers.
+    ///
+    /// Defaults to `true`.
+    ///
+    /// Current enabling this makes us append `?code_file=...&code_id=...` to
+    /// `.sym` queries. Native binary queries are unaffected, but this may change in
+    /// the future if anyone has a compelling reason to add them.
+    ///
+    /// The extra parameters can help the symbol server log and backfill failed symbol
+    /// queries, but aren't part of the official symbol server protocol. Microsoft's
+    /// servers don't care if they're there even for native queries, but you can disable
+    /// them if you really want.
+    pub append_debug_query_params: bool,
+}
+
+impl Default for HttpSymbolSupplierOptions {
+    fn default() -> Self {
+        Self {
+            urls: vec![],
+            cache: None,
+            tmp: Some(std::env::temp_dir()),
+            local_paths: vec![],
+            timeout: Duration::from_secs(1000),
+            fetch_syms: true,
+            fetch_native_binaries: cfg!(feature = "dump_syms"),
+            use_minidump_paths: false,
+            append_debug_query_params: true,
+        }
+    }
+}
+
 /// An implementation of `SymbolSupplier` that loads Breakpad text-format
 /// symbols from HTTP URLs.
 ///
 /// See [`crate::breakpad_sym_lookup`] for details on how paths are searched.
+///
+/// See [`HttpSymbolSupplierOptions`][] for various options and details on how urls are queried.
 pub struct HttpSymbolSupplier {
     /// File paths that are known to be in the cache
     #[allow(clippy::type_complexity)]
@@ -27,18 +222,18 @@ pub struct HttpSymbolSupplier {
     /// A `SimpleSymbolSupplier` to use for local symbol paths.
     local: SimpleSymbolSupplier,
     /// A path at which to cache downloaded symbols.
-    ///
-    /// We recommend using a subdirectory of `std::env::temp_dir()`, as this
-    /// will be your OS's intended location for tempory files. This should
-    /// give you free garbage collection of the cache while still allowing it
-    /// to function between runs.
-    cache: PathBuf,
+    cache: Option<PathBuf>,
     /// A path to a temporary location where downloaded symbols can be written
     /// before being atomically swapped into the cache.
-    ///
-    /// We recommend using `std::env::temp_dir()`, as this will be your OS's
-    /// intended location for temporary files.
-    tmp: PathBuf,
+    tmp: Option<PathBuf>,
+    /// Whether to fetch .sym files over http.
+    fetch_syms: bool,
+    /// Whether to fetch native binaries over http.
+    fetch_native_binaries: bool,
+    /// Whether to try to use the full paths for codefiles/debugfiles in the minidump.
+    use_minidump_paths: bool,
+    /// Whether to append extra debugging arguments as `?query` params to URLs.
+    append_debug_query_params: bool,
 }
 
 impl HttpSymbolSupplier {
@@ -47,15 +242,10 @@ impl HttpSymbolSupplier {
     /// Symbols will be searched for in each of `local_paths` and `cache` first,
     /// then via HTTP at each of `urls`. If a symbol file is found via HTTP it
     /// will be saved under `cache`.
-    pub fn new(
-        urls: Vec<String>,
-        cache: PathBuf,
-        tmp: PathBuf,
-        mut local_paths: Vec<PathBuf>,
-        timeout: Duration,
-    ) -> HttpSymbolSupplier {
-        let client = Client::builder().timeout(timeout).build().unwrap();
-        let urls = urls
+    pub fn new(options: HttpSymbolSupplierOptions) -> HttpSymbolSupplier {
+        let client = Client::builder().timeout(options.timeout).build().unwrap();
+        let urls = options
+            .urls
             .into_iter()
             .filter_map(|mut u| {
                 if !u.ends_with('/') {
@@ -64,16 +254,32 @@ impl HttpSymbolSupplier {
                 Url::parse(&u).ok()
             })
             .collect();
-        local_paths.push(cache.clone());
+        let mut local_paths = options.local_paths;
+        if let Some(cache) = options.cache.clone() {
+            local_paths.push(cache);
+        }
         let local = SimpleSymbolSupplier::new(local_paths);
         let cached_file_paths = Mutex::default();
+
+        if !cfg!(feature = "dump_syms") {
+            if options.fetch_native_binaries {
+                warn!("fetch_native_binaries is enabled, but the dump_syms feature is cfg'd off!");
+            }
+            if options.use_minidump_paths {
+                warn!("use_minidump_paths is enabled, but the dump_syms feature is cfg'd off!");
+            }
+        }
         HttpSymbolSupplier {
             client,
             cached_file_paths,
             urls,
             local,
-            cache,
-            tmp,
+            cache: options.cache,
+            tmp: options.tmp,
+            fetch_native_binaries: options.fetch_native_binaries,
+            fetch_syms: options.fetch_syms,
+            use_minidump_paths: options.use_minidump_paths,
+            append_debug_query_params: options.append_debug_query_params,
         }
     }
 
@@ -105,8 +311,14 @@ impl HttpSymbolSupplier {
                 // unlikely to get multiple hits... this might actually be ok!
                 if let Some(lookup) = lookup(module, file_kind) {
                     for url in &self.urls {
-                        let fetch =
-                            fetch_lookup(&self.client, url, &lookup, &self.cache, &self.tmp).await;
+                        let fetch = fetch_lookup(
+                            &self.client,
+                            url,
+                            &lookup,
+                            self.cache.as_deref(),
+                            self.tmp.as_deref(),
+                        )
+                        .await;
 
                         if let Ok((path, url)) = fetch {
                             return Ok((path, url));
@@ -120,8 +332,8 @@ impl HttpSymbolSupplier {
                                 &self.client,
                                 url,
                                 &lookup,
-                                &self.cache,
-                                &self.tmp,
+                                self.cache.as_deref(),
+                                self.tmp.as_deref(),
                             )
                             .await;
 
@@ -192,8 +404,9 @@ async fn fetch_symbol_file(
     client: &Client,
     base_url: &Url,
     module: &(dyn Module + Sync),
-    cache: &Path,
-    tmp: &Path,
+    cache: Option<&Path>,
+    tmp: Option<&Path>,
+    append_debug_query_params: bool,
 ) -> Result<SymbolFile, SymbolError> {
     trace!("HttpSymbolSupplier trying symbol server {}", base_url);
     // This function is a bit of a complicated mess because we want to write
@@ -210,10 +423,13 @@ async fn fetch_symbol_file(
     let mut url = base_url
         .join(&sym_lookup.server_rel)
         .map_err(|_| SymbolError::NotFound)?;
-    let code_id = module.code_identifier().unwrap_or_default();
-    url.query_pairs_mut()
-        .append_pair("code_file", crate::basename(&module.code_file()))
-        .append_pair("code_id", code_id.as_str());
+
+    if append_debug_query_params {
+        let code_id = module.code_identifier().unwrap_or_default();
+        url.query_pairs_mut()
+            .append_pair("code_file", crate::basename(&module.code_file()))
+            .append_pair("code_id", code_id.as_str());
+    }
     debug!("Trying {}", url);
     let res = client
         .get(url.clone())
@@ -223,17 +439,22 @@ async fn fetch_symbol_file(
         .map_err(|_| SymbolError::NotFound)?;
 
     // Now try to create the temp cache file (not yet in the cache)
-    let final_cache_path = cache.join(sym_lookup.cache_rel);
-    let mut temp = create_cache_file(tmp, &final_cache_path)
-        .map_err(|e| {
-            warn!("Failed to save symbol file in local disk cache: {}", e);
-        })
-        .ok();
+
+    let mut temp = cache.and_then(|cache| {
+        let final_cache_path = cache.join(sym_lookup.cache_rel);
+        let tmp = tmp.expect("set cache but unset tmp?!");
+        let file = create_cache_file(tmp, &final_cache_path)
+            .map_err(|e| {
+                warn!("Failed to save symbol file in local disk cache: {}", e);
+            })
+            .ok()?;
+        Some((file, final_cache_path))
+    });
 
     // Now stream parse the file as it downloads.
     let mut symbol_file = SymbolFile::parse_async(res, |data| {
         // While we're downloading+parsing, save this data to the the disk cache too
-        if let Some(file) = temp.as_mut() {
+        if let Some((file, _path)) = temp.as_mut() {
             if let Err(e) = file.write_all(data) {
                 // Give up on caching this.
                 warn!("Failed to save symbol file in local disk cache: {}", e);
@@ -246,7 +467,7 @@ async fn fetch_symbol_file(
     symbol_file.url = Some(url.to_string());
 
     // Try to finish the cache file and atomically swap it into the cache.
-    if let Some(temp) = temp {
+    if let Some((temp, final_cache_path)) = temp {
         let _ = commit_cache_file(temp, &final_cache_path, &url).map_err(|e| {
             warn!("Failed to save symbol file in local disk cache: {}", e);
         });
@@ -263,9 +484,15 @@ async fn fetch_lookup(
     client: &Client,
     base_url: &Url,
     lookup: &FileLookup,
-    cache: &Path,
-    tmp: &Path,
+    cache: Option<&Path>,
+    tmp: Option<&Path>,
 ) -> Result<(PathBuf, Option<Url>), SymbolError> {
+    let (cache, tmp) = if let (Some(cache), Some(tmp)) = (cache, tmp) {
+        (cache, tmp)
+    } else {
+        warn!("Fetching native binaries currently requires both cache and tmp!");
+        return Err(SymbolError::NotFound);
+    };
     // First try to GET the file from a server
     let url = base_url
         .join(&lookup.server_rel)
@@ -305,8 +532,8 @@ async fn fetch_cab_lookup(
     client: &Client,
     base_url: &Url,
     lookup: &FileLookup,
-    cache: &Path,
-    tmp: &Path,
+    cache: Option<&Path>,
+    tmp: Option<&Path>,
 ) -> Result<(PathBuf, Option<Url>), FileError> {
     let cab_lookup = moz_lookup(lookup.clone());
     // First try to GET the file from a server
@@ -335,8 +562,8 @@ async fn fetch_cab_lookup(
     _client: &Client,
     _base_url: &Url,
     _lookup: &FileLookup,
-    _cache: &Path,
-    _tmp: &Path,
+    _cache: Option<&Path>,
+    _tmp: Option<&Path>,
 ) -> Result<(PathBuf, Option<Url>), FileError> {
     Err(FileError::NotFound)
 }
@@ -348,6 +575,12 @@ pub fn unpack_cabinet_file(
     cache: &Path,
     tmp: &Path,
 ) -> Result<PathBuf, std::io::Error> {
+    let (cache, tmp) = if let (Some(cache), Some(tmp)) = (cache, tmp) {
+        (cache, tmp)
+    } else {
+        warn!("Fetching native binaries currently requires both cache and tmp!");
+        return Err(SymbolError::NotFound);
+    };
     trace!("symbols: unpacking CAB file: {}", lookup.cache_rel);
     // try to find a file in a cabinet archive and unpack it to the destination
     use cab::Cabinet;
@@ -484,46 +717,69 @@ impl SymbolSupplier for HttpSymbolSupplier {
         trace!("HttpSymbolSupplier search (SimpleSymbolSupplier found nothing)");
 
         // Second: try to directly download sym files
-        for url in &self.urls {
-            // First, try to get a breakpad .sym file from the symbol server
-            let sym = fetch_symbol_file(&self.client, url, module, &self.cache, &self.tmp).await;
-            match sym {
-                Ok(file) => {
-                    trace!("HttpSymbolSupplier parsed file!");
-                    return Ok(file);
-                }
-                Err(e) => {
-                    trace!("HttpSymbolSupplier failed: {}", e);
+        if self.fetch_syms {
+            for url in &self.urls {
+                // First, try to get a breakpad .sym file from the symbol server
+                let sym = fetch_symbol_file(
+                    &self.client,
+                    url,
+                    module,
+                    self.cache.as_deref(),
+                    self.tmp.as_deref(),
+                    self.append_debug_query_params,
+                )
+                .await;
+                match sym {
+                    Ok(file) => {
+                        trace!("HttpSymbolSupplier parsed file!");
+                        return Ok(file);
+                    }
+                    Err(e) => {
+                        trace!("HttpSymbolSupplier failed: {}", e);
+                    }
                 }
             }
         }
 
         // Third: try to generate a symfile from native symbols
-        if cfg!(feature = "dump_syms") {
-            trace!("symbols: trying to fetch native symbols");
-            // Find native files
-            let mut native_artifacts = vec![];
-            native_artifacts.push(self.locate_file_internal(module, FileKind::Binary).await);
-            native_artifacts.push(
-                self.locate_file_internal(module, FileKind::ExtraDebugInfo)
-                    .await,
-            );
+        if cfg!(feature = "dump_syms") && self.fetch_native_binaries {
+            if let (Some(cache), Some(_tmp)) = (self.cache.as_ref(), self.tmp.as_ref()) {
+                trace!("symbols: trying to fetch native symbols");
+                // Find native files
+                let mut native_artifacts = vec![];
+                native_artifacts.push(self.locate_file_internal(module, FileKind::Binary).await);
+                native_artifacts.push(
+                    self.locate_file_internal(module, FileKind::ExtraDebugInfo)
+                        .await,
+                );
 
-            // Now try to run dump_syms to produce a .sym
-            let sym_lookup =
-                breakpad_sym_lookup(module).ok_or(SymbolError::MissingDebugFileOrId)?;
-            let output = self.cache.join(sym_lookup.cache_rel);
-            if dump_syms(&native_artifacts, &output).await.is_ok() {
-                trace!("symbols: dump_syms successful! using local result");
-                // We want dump_syms to leave us in a state "as if" we had downloaded
-                // the symbol file, so as a guard against that diverging, we now use
-                // the proper cache-lookup path to read the file dump_syms just wrote.
-                if let Ok(local_result) = self.local.locate_symbols(module).await {
-                    return Ok(local_result);
-                } else {
-                    warn!("dump_syms succeeded, but there was no symbol file in the cache?");
+                // Now try to run dump_syms to produce a .sym
+                let sym_lookup =
+                    breakpad_sym_lookup(module).ok_or(SymbolError::MissingDebugFileOrId)?;
+                let output = cache.join(sym_lookup.cache_rel);
+                if dump_syms(&native_artifacts, &output).await.is_ok() {
+                    trace!("symbols: dump_syms successful! using local result");
+                    // We want dump_syms to leave us in a state "as if" we had downloaded
+                    // the symbol file, so as a guard against that diverging, we now use
+                    // the proper cache-lookup path to read the file dump_syms just wrote.
+                    if let Ok(local_result) = self.local.locate_symbols(module).await {
+                        return Ok(local_result);
+                    } else {
+                        warn!("dump_syms succeeded, but there was no symbol file in the cache?");
+                    }
                 }
-            }
+            } else {
+                warn!("Unfortunately the current dump_syms impl requires both a cache and tmp!")
+            };
+        }
+
+        // Fourth: try minidump paths
+        if cfg!(feature = "dump_syms") && self.use_minidump_paths {
+            if let (Some(_cache), Some(_tmp)) = (self.cache.as_ref(), self.tmp.as_ref()) {
+                warn!("use_minidump_paths feature isn't yet implemented!")
+            } else {
+                panic!("Unfortunately the current dump_syms impl requires both a cache and tmp!")
+            };
         }
 
         // If we get this far, we have failed to find anything

--- a/breakpad-symbols/src/http.rs
+++ b/breakpad-symbols/src/http.rs
@@ -667,6 +667,7 @@ async fn dump_syms(
     }
 
     trace!("Running dump_syms on {}...", source_file.unwrap().display());
+    std::fs::create_dir_all(output.parent().unwrap())?;
 
     if let Err(e) = dumper::single_file(
         &dumper::Config {

--- a/minidump-processor/src/symbols.rs
+++ b/minidump-processor/src/symbols.rs
@@ -339,7 +339,7 @@ pub fn http_symbol_supplier(
 }
 
 /// Gets a SymbolSupplier that looks up symbols by path or with urls.
-/// 
+///
 /// See [`HttpSymbolSupplierOptions`][] for details.
 #[cfg(feature = "http")]
 pub fn http_symbol_supplier_opt(options: HttpSymbolSupplierOptions) -> impl SymbolSupplier {

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__long-help.snap
@@ -183,6 +183,47 @@ OPTIONS:
             
             [default: 1000]
 
+        --fetch-syms <FETCH_SYMS>
+            Whether to query urls for .sym files.
+            
+            Defaults to `true`.
+            
+            This mode works with "fake" Microsoft Symbol Servers like Tecken, and is the mode that
+            breakpad-symbols was designed for. These files are generally significantly smaller than
+            a codefile or debugfile, where symbols natively reside.
+            
+            [possible values: true, false]
+
+        --fetch-native-binaries <FETCH_NATIVE_BINARIES>
+            Whether to query urls for native codefiles and debugfiles.
+            
+            Currently defaults to `cfg!(feature = dump_syms)` (experimental).
+            
+            Setting this to `true` will do nothing if the `dump_syms` feature isn't also enabled.
+            
+            This mode works with "real" Microsoft Symbol Servers, and is experimental.
+            
+            [possible values: true, false]
+
+        --use-minidump-paths <USE_MINIDUMP_PATHS>
+            Whether to try to get symbols from the *actual* codefile and debugfile paths on the
+            current system.
+            
+            Currently defaults to `false` (experimental).
+            
+            Setting this to `true` will do nothing if the `dump_syms` feature isn't also enabled.
+            
+            The actual codefile and debugfile entries in a minidump are actually complete paths from
+            either the machine where the program was running, or the machine where the build was
+            performed. Either way, this means processing a minidump on the same machine that the
+            crash occured on can yield some symbols at those paths. This works especially well for
+            local development where "build machine" and "run machine" are the same, and the
+            executable is still in the build dir with ALL the debuginfo the compiler emitted!
+            
+            If `cache` is set, we *may* place a `sym` in it to optimize subsequent runs.
+            
+            [possible values: true, false]
+
         --symbols-path <SYMBOLS_PATH>
             Path to a symbol file.
             

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__markdown-help.snap
@@ -190,6 +190,47 @@ This is necessary to enforce forward progress on misbehaving http responses.
 
 \[default: 1000]  
 
+#### `--fetch-syms <FETCH_SYMS>`
+Whether to query urls for .sym files.
+
+Defaults to `true`.
+
+This mode works with "fake" Microsoft Symbol Servers like Tecken, and is the mode that
+breakpad-symbols was designed for. These files are generally significantly smaller than
+a codefile or debugfile, where symbols natively reside.
+
+\[possible values: true, false]  
+
+#### `--fetch-native-binaries <FETCH_NATIVE_BINARIES>`
+Whether to query urls for native codefiles and debugfiles.
+
+Currently defaults to `cfg!(feature = dump_syms)` (experimental).
+
+Setting this to `true` will do nothing if the `dump_syms` feature isn't also enabled.
+
+This mode works with "real" Microsoft Symbol Servers, and is experimental.
+
+\[possible values: true, false]  
+
+#### `--use-minidump-paths <USE_MINIDUMP_PATHS>`
+Whether to try to get symbols from the *actual* codefile and debugfile paths on the
+current system.
+
+Currently defaults to `false` (experimental).
+
+Setting this to `true` will do nothing if the `dump_syms` feature isn't also enabled.
+
+The actual codefile and debugfile entries in a minidump are actually complete paths from
+either the machine where the program was running, or the machine where the build was
+performed. Either way, this means processing a minidump on the same machine that the
+crash occured on can yield some symbols at those paths. This works especially well for
+local development where "build machine" and "run machine" are the same, and the
+executable is still in the build dir with ALL the debuginfo the compiler emitted!
+
+If `cache` is set, we *may* place a `sym` in it to optimize subsequent runs.
+
+\[possible values: true, false]  
+
 #### `--symbols-path <SYMBOLS_PATH>`
 Path to a symbol file.
 

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__short-help.snap
@@ -70,6 +70,16 @@ OPTIONS:
             The maximum amount of time (in seconds) a symbol file download is allowed to take
             [default: 1000]
 
+        --fetch-syms <FETCH_SYMS>
+            Whether to query urls for .sym files [possible values: true, false]
+
+        --fetch-native-binaries <FETCH_NATIVE_BINARIES>
+            Whether to query urls for native codefiles and debugfiles [possible values: true, false]
+
+        --use-minidump-paths <USE_MINIDUMP_PATHS>
+            Whether to try to get symbols from the *actual* codefile and debugfile paths on the
+            current system [possible values: true, false]
+
         --symbols-path <SYMBOLS_PATH>
             Path to a symbol file
 


### PR DESCRIPTION
* Add a bunch of options to http symbol supplier so it's easier to turn on/off the various symbol lookup modes / features.
* Add an expandable options struct and a new constructor function for using the options struct
* Add a new use_minidump_paths mode to run dump_syms on the codefile and debugfile *paths* in the minidump, enabling local symbolication on the same machine that crashed/built
* Expose some of those options as minidump-stackwalk flags