### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          # (optional) Path to changelog.
+          changelog: RELEASES.md
+          # (required) GitHub token for creating GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: minidump-stackwalk
+          # (optional) Target triple, default is host triple.
+          target: ${{ matrix.target }}
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,9 @@ members = [
 exclude = [
     "testdata/*",
 ]
+
+[workspace.metadata.release]
+shared-version = true
+consolidate-commits = true
+consolidate-pushes = true
+tag-name = "v{{version}}"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,7 @@
-# Version XXX (not yet released)
+<!-- next-header -->
+# Next Version
 
-Nothing to see here yet!
+TODO
 
 # Version 0.14.0 (2022-08-03)
 

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -36,3 +36,12 @@ tracing-subscriber = "0.3.14"
 insta = "1.13.0"
 minidump-synth = { path = "../minidump-synth" }
 test-assembler = "0.1.6"
+
+[package.metadata.release]
+pre-release-replacements = [
+  {file="../RELEASES.md", search="Next Version", replace="Version {{version}} ({{date}})", min=1},
+  {file="../RELEASES.md", search="<!-- next-header -->", replace="<!-- next-header -->\n# Next Version\n", exactly=1},
+  {file="tests/snapshots/test_minidump_stackwalk__markdown-help.snap",  search="minidump-stackwalk 0.*`", replace="minidump-stackwalk {{version}}`", exactly=1},
+  {file="tests/snapshots/test_minidump_stackwalk__long-help.snap",  search="minidump-stackwalk 0.*", replace="minidump-stackwalk {{version}}", exactly=1},
+  {file="tests/snapshots/test_minidump_stackwalk__short-help.snap", search="minidump-stackwalk 0.*", replace="minidump-stackwalk {{version}}", exactly=1}
+]

--- a/minidump-stackwalk/tests/test-minidump-stackwalk.rs
+++ b/minidump-stackwalk/tests/test-minidump-stackwalk.rs
@@ -466,7 +466,13 @@ fn test_version() {
     let mut ver_parts = ver.trim().split('.');
     ver_parts.next().unwrap().parse::<u8>().unwrap();
     ver_parts.next().unwrap().parse::<u8>().unwrap();
-    ver_parts.next().unwrap().parse::<u8>().unwrap();
+    let last = ver_parts.next().unwrap();
+    if let Some((last, _prerelease)) = last.split_once('-') {
+        last.parse::<u8>().unwrap();
+    } else {
+        last.parse::<u8>().unwrap();
+    }
+
     assert!(ver_parts.next().is_none());
 }
 


### PR DESCRIPTION
With these changes, if you type:

```
cargo release 0.15.0 --execute
```

It will:

* update all the versions in Cargo.tomls
* update a bunch of version strings in RELEASES and snapshot tests
* tag v0.15.0
* push to main (with the tag)
* cargo publish

Then CI will see the tag and:

* create a github release with the notes from RELEASES.md
* create tarballs/zips for windows/macos/linux * x64/arm64

This makes the main chore of a release "making sure the "Next Release" entry has the releases notes you want (manual, intentionally). Potentially this should have a post-release hook to add the commit SHA as I currently do manually... problem for later.