### PR TITLE
Fix cargo-release replacements

### DIFF
--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -41,7 +41,4 @@ test-assembler = "0.1.6"
 pre-release-replacements = [
   {file="../RELEASES.md", search="Next Version", replace="Version {{version}} ({{date}})", min=1},
   {file="../RELEASES.md", search="<!-- next-header -->", replace="<!-- next-header -->\n# Next Version\n", exactly=1},
-  {file="tests/snapshots/test_minidump_stackwalk__markdown-help.snap",  search="minidump-stackwalk 0.*`", replace="minidump-stackwalk {{version}}`", exactly=1},
-  {file="tests/snapshots/test_minidump_stackwalk__long-help.snap",  search="minidump-stackwalk 0.*", replace="minidump-stackwalk {{version}}", exactly=1},
-  {file="tests/snapshots/test_minidump_stackwalk__short-help.snap", search="minidump-stackwalk 0.*", replace="minidump-stackwalk {{version}}", exactly=1}
 ]


### PR DESCRIPTION
Cargo release was broken by accident when updating clap in 06348c251b3165741a6a6e744f02baef5da6c64d which removed the version line (Version: `minidump-stackwalk 0.14.0`) from the output, but missed removing the version number replacement in pre-release-replacements.

Fixes the issue observed in #724