### PR TITLE
Improve the handling of CPU microcode values.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ fuzzing tests (see the `cargo fuzz` section):
 
 ## minidump-synth: Synthetic Minidumps for Tests
 
-rust-minidump includes a [synthetic minidump generator](minidump-synth) which lets you come up with a high-level description of the contents of a minidump, and then produces an actual minidump binary that we can feed it into the full parser.
+rust-minidump includes a [synthetic minidump generator](minidump-synth) which lets you come up with a high-level description of the contents of a minidump, and then produces an actual minidump binary that we can feed into the full parser.
 
 This is used throughout the codebase. Being able to use minidump-synth and add things to it is very important! This can in turn involve the test_assembler crate, which we discuss in the next section. Thankfully you don't need to master these systems: there's usually already code/tests for something *similar* which you can copy-paste and tweak. 
 
@@ -192,7 +192,7 @@ fn test_crashpad_info_annotations() {
 
 One of the major pieces of testing infra we rely on is [test_assembler](https://github.com/luser/rust-test-assembler), which allows us to construct artificial binaries with a combination of the builder pattern and *labels* which essentially represent variables which will have their values filled in later. The primary purpose of labels is that they let us refer to offsets in the binary we're writing, *even in the binary itself*, **even when those offsets aren't defined yet**.
 
-The place where you'll see this most is in our stackwalker tests, where we artificially construct the memory a stack we want to walk. Things like frame pointers are *precisely* pointers to later parts of the stack. Here's an [example frame pointery stack in the amd64 tests](https://github.com/rust-minidump/rust-minidump/blob/2001547fcf4aa0f28f52b8b1ab5da9bd99c8ac87/minidump-processor/src/stackwalker/amd64_unittest.rs#L82-L116):
+The place where you'll see this most is in our stackwalker tests, where we artificially construct the memory of a stack we want to walk. Things like frame pointers are *precisely* pointers to later parts of the stack. Here's an [example frame pointery stack in the amd64 tests](https://github.com/rust-minidump/rust-minidump/blob/2001547fcf4aa0f28f52b8b1ab5da9bd99c8ac87/minidump-processor/src/stackwalker/amd64_unittest.rs#L82-L116):
 
 ```rust ,ignore
 // Functions typically push their %rbp upon entry and set %rbp pointing
@@ -209,7 +209,7 @@ let return_address = 0x00007500b0000110;
 // The `start` constant is the address this section should claim to start at.
 // This affects the addresses that Labels will report when we query offsets
 // in the binary. In this way we can easily test corner cases and get exact
-// addresses when we want to test overflow/underflow/truncaction bugs.
+// addresses when we want to test overflow/underflow/truncation bugs.
 stack.start().set_const(stack_start);
 
 // We will be querying these 3 offsets in the binary.

--- a/minidump-processor/src/evil.rs
+++ b/minidump-processor/src/evil.rs
@@ -14,6 +14,8 @@ pub(crate) struct Evil {
     pub certs: HashMap<String, String>,
     /// thread id => thread name
     pub thread_names: HashMap<u32, String>,
+    /// The microcode version of the cpu
+    pub cpu_microcode_version: Option<String>,
 }
 
 pub(crate) fn handle_evil(evil_path: &Path) -> Option<Evil> {
@@ -96,8 +98,15 @@ pub(crate) fn handle_evil(evil_path: &Path) -> Option<Evil> {
         })
         .collect();
 
+    // The CPUMicrocodeVersion field is a hex string starting with "0x"; the string formatting will
+    // be verified later.
+    let cpu_microcode_version = json
+        .remove("CPUMicrocodeVersion")
+        .and_then(|v| Some(v.as_str()?.to_owned()));
+
     Some(Evil {
         certs,
         thread_names,
+        cpu_microcode_version,
     })
 }

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -917,8 +917,8 @@ Unknown streams encountered:
                 "cpu_arch": sys.cpu.to_string(),
                 "cpu_info": sys.cpu_info,
                 "cpu_count": sys.cpu_count,
-                // optional
-                "cpu_microcode_version": sys.cpu_microcode_version,
+                // optional, print as hex string
+                "cpu_microcode_version": sys.cpu_microcode_version.map(|num| format!("{:#018x}", num)),
             },
             "crash_info": {
                 "type": self.exception_info.as_ref().map(|info| info.reason).map(|reason| reason.to_string()),

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -918,7 +918,7 @@ Unknown streams encountered:
                 "cpu_info": sys.cpu_info,
                 "cpu_count": sys.cpu_count,
                 // optional, print as hex string
-                "cpu_microcode_version": sys.cpu_microcode_version.map(|num| format!("{:#018x}", num)),
+                "cpu_microcode_version": sys.cpu_microcode_version.map(|num| format!("{:#x}", num)),
             },
             "crash_info": {
                 "type": self.exception_info.as_ref().map(|info| info.reason).map(|reason| reason.to_string()),

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -483,7 +483,7 @@ where
                 None
             }
         })
-        .or_else(|| evil.cpu_microcode_version.as_ref().map(|s| s.as_str()))
+        .or(evil.cpu_microcode_version.as_deref())
         .and_then(|val| val.strip_prefix("0x"))
         .and_then(|val| u64::from_str_radix(val, 16).ok());
 


### PR DESCRIPTION
This reads the CPUMicrocodeVersion field from `--evil-json` and uses that if no other microcode version information is available in the minidump. It also changes output to print the microcode version as a hex string.

Closes #683.

One thing that isn't clear: should the output microcode version be 0-padded or not?