### PR TITLE
Introduce UnifiedMemoryList and UnifiedMemory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn main() -> Result<(), Error> {
         // Use `Default` to try to make progress when a stream is missing.
         // This is especially natural for MinidumpMemoryList because
         // everything needs to handle memory lookups failing anyway.
-        let mem = UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default());
+        let mem = dump.get_memory().unwrap_or_default();
 
         for thread in &threads.threads {
             let stack = thread.stack_memory(&mem);

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn main() -> Result<(), Error> {
         // Use `Default` to try to make progress when a stream is missing.
         // This is especially natural for MinidumpMemoryList because
         // everything needs to handle memory lookups failing anyway.
-        let mem = dump.get_stream::<MinidumpMemoryList>().unwrap_or_default();
+        let mem = UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default());
 
         for thread in &threads.threads {
             let stack = thread.stack_memory(&mem);

--- a/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
+++ b/minidump-processor/fuzz/fuzz_targets/walk_stack.rs
@@ -2,7 +2,7 @@
 use libfuzzer_sys::fuzz_target;
 
 use minidump::system_info::{Cpu, Os};
-use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory};
+use minidump::{MinidumpContext, MinidumpContextValidity, MinidumpMemory, UnifiedMemory};
 use minidump::{MinidumpModule, MinidumpModuleList};
 use minidump_processor::walk_stack;
 use minidump_processor::{string_symbol_supplier, CallStack, ProcessorOptions,  Symbolizer, SystemInfo};
@@ -63,7 +63,7 @@ impl TestFixture {
             0,
             &options,
             &mut stack,
-            Some(&stack_memory),
+            Some(UnifiedMemory::Memory(&stack_memory)),
             &self.modules,
             &system_info,
             &symbolizer,

--- a/minidump-processor/src/arg_recovery.rs
+++ b/minidump-processor/src/arg_recovery.rs
@@ -1,5 +1,5 @@
 use crate::{CallStack, CallingConvention, FunctionArg, FunctionArgs};
-use minidump::{CpuContext, MinidumpMemory, MinidumpRawContext};
+use minidump::{CpuContext, MinidumpRawContext, UnifiedMemory};
 
 // # Recovering x86 function arguments
 //
@@ -67,7 +67,7 @@ use minidump::{CpuContext, MinidumpMemory, MinidumpRawContext};
 // are worth carving out special cases for, but until then: it's all pointers!
 
 /// Try to recover function arguments
-pub fn fill_arguments(call_stack: &mut CallStack, stack_memory: Option<&MinidumpMemory>) {
+pub fn fill_arguments(call_stack: &mut CallStack, stack_memory: Option<UnifiedMemory>) {
     // Collect up all the results at once to avoid borrowing issues.
     let args = call_stack
         .frames
@@ -91,7 +91,7 @@ pub fn fill_arguments(call_stack: &mut CallStack, stack_memory: Option<&Minidump
                     // is actually the base of the stack. Since we're walking down
                     // the stack, the base of the stack is a good upper-bound
                     // (and default value) for any stack/frame pointer.
-                    let stack_base = mem.base_address.saturating_add(mem.size);
+                    let stack_base = mem.base_address().saturating_add(mem.size());
 
                     let caller_stack_pointer = call_stack
                         .frames

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -559,13 +559,7 @@ where
         // Just give an empty list, simplifies things.
         Err(_) => MinidumpUnloadedModuleList::new(),
     };
-    let memory_list = dump
-        .get_stream::<MinidumpMemory64List>()
-        .ok()
-        .map(UnifiedMemoryList::Memory64)
-        .unwrap_or_else(|| {
-            UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default())
-        });
+    let memory_list = dump.get_memory().unwrap_or_default();
     let memory_info_list = dump.get_stream::<MinidumpMemoryInfoList>().ok();
     let linux_maps = dump.get_stream::<MinidumpLinuxMaps>().ok();
     let memory_info = UnifiedMemoryInfoList::new(memory_info_list, linux_maps).unwrap_or_default();

--- a/minidump-processor/src/stackwalker/amd64_unittest.rs
+++ b/minidump-processor/src/stackwalker/amd64_unittest.rs
@@ -48,7 +48,7 @@ impl TestFixture {
         let base = stack.start().value().unwrap();
         let size = stack.size();
         let stack = stack.get_contents().unwrap();
-        let stack_memory = MinidumpMemory {
+        let stack_memory = &MinidumpMemory {
             desc: Default::default(),
             base_address: base,
             size,
@@ -63,7 +63,7 @@ impl TestFixture {
             0,
             &options,
             &mut stack,
-            Some(&stack_memory),
+            Some(UnifiedMemory::Memory(stack_memory)),
             &self.modules,
             &self.system_info,
             &symbolizer,

--- a/minidump-processor/src/stackwalker/arm.rs
+++ b/minidump-processor/src/stackwalker/arm.rs
@@ -10,8 +10,8 @@ use crate::stackwalker::CfiStackWalker;
 use crate::{SymbolProvider, SystemInfo};
 use minidump::system_info::Os;
 use minidump::{
-    CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpMemory, MinidumpModuleList,
-    MinidumpRawContext,
+    CpuContext, MinidumpContext, MinidumpContextValidity, MinidumpModuleList, MinidumpRawContext,
+    UnifiedMemory,
 };
 use std::collections::HashSet;
 use tracing::trace;
@@ -31,7 +31,7 @@ async fn get_caller_by_cfi<P>(
     ctx: &ArmContext,
     callee: &StackFrame,
     grand_callee: Option<&StackFrame>,
-    stack_memory: &MinidumpMemory<'_>,
+    stack_memory: UnifiedMemory<'_, '_>,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> Option<StackFrame>
@@ -100,7 +100,7 @@ fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static st
 fn get_caller_by_frame_pointer<P>(
     ctx: &ArmContext,
     callee: &StackFrame,
-    stack_memory: &MinidumpMemory<'_>,
+    stack_memory: UnifiedMemory<'_, '_>,
     _modules: &MinidumpModuleList,
     system_info: &SystemInfo,
     _symbol_provider: &P,
@@ -186,7 +186,7 @@ where
 async fn get_caller_by_scan<P>(
     ctx: &ArmContext,
     callee: &StackFrame,
-    stack_memory: &MinidumpMemory<'_>,
+    stack_memory: UnifiedMemory<'_, '_>,
     modules: &MinidumpModuleList,
     symbol_provider: &P,
 ) -> Option<StackFrame>
@@ -290,7 +290,7 @@ where
 fn stack_seems_valid(
     caller_sp: Pointer,
     callee_sp: Pointer,
-    stack_memory: &MinidumpMemory<'_>,
+    stack_memory: UnifiedMemory<'_, '_>,
 ) -> bool {
     // The stack shouldn't *grow* when we unwind
     if caller_sp < callee_sp {
@@ -310,7 +310,7 @@ impl Unwind for ArmContext {
         &self,
         callee: &StackFrame,
         grand_callee: Option<&StackFrame>,
-        stack_memory: Option<&MinidumpMemory<'_>>,
+        stack_memory: Option<UnifiedMemory<'_, '_>>,
         modules: &MinidumpModuleList,
         system_info: &SystemInfo,
         syms: &P,
@@ -318,7 +318,7 @@ impl Unwind for ArmContext {
     where
         P: SymbolProvider + Sync,
     {
-        let stack = stack_memory.as_ref()?;
+        let stack = stack_memory?;
 
         // .await doesn't like closures, so don't use Option chaining
         let mut frame = None;

--- a/minidump-processor/src/stackwalker/arm64_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm64_unittest.rs
@@ -93,7 +93,7 @@ impl TestFixture {
             0,
             &options,
             &mut stack,
-            Some(&stack_memory),
+            Some(UnifiedMemory::Memory(&stack_memory)),
             &self.modules,
             &system_info,
             &symbolizer,

--- a/minidump-processor/src/stackwalker/arm_unittest.rs
+++ b/minidump-processor/src/stackwalker/arm_unittest.rs
@@ -63,7 +63,7 @@ impl TestFixture {
             0,
             &options,
             &mut stack,
-            Some(&stack_memory),
+            Some(UnifiedMemory::Memory(&stack_memory)),
             &self.modules,
             &self.system_info,
             &symbolizer,

--- a/minidump-processor/src/stackwalker/mod.rs
+++ b/minidump-processor/src/stackwalker/mod.rs
@@ -32,7 +32,7 @@ struct CfiStackWalker<'a, C: CpuContext> {
     caller_ctx: C,
     caller_validity: HashSet<&'static str>,
 
-    stack_memory: &'a MinidumpMemory<'a>,
+    stack_memory: UnifiedMemory<'a, 'a>,
 }
 
 impl<'a, C> FrameWalker for CfiStackWalker<'a, C>
@@ -90,7 +90,7 @@ async fn get_caller_frame<P>(
     _frame_idx: usize,
     callee_frame: &StackFrame,
     grand_callee_frame: Option<&StackFrame>,
-    stack_memory: Option<&MinidumpMemory<'_>>,
+    stack_memory: Option<UnifiedMemory<'_, '_>>,
     modules: &MinidumpModuleList,
     system_info: &SystemInfo,
     symbol_provider: &P,
@@ -203,7 +203,7 @@ pub async fn walk_stack<P>(
     thread_idx: usize,
     options: &ProcessorOptions<'_>,
     stack: &mut CallStack,
-    stack_memory: Option<&MinidumpMemory<'_>>,
+    stack_memory: Option<UnifiedMemory<'_, '_>>,
     modules: &MinidumpModuleList,
     system_info: &SystemInfo,
     symbol_provider: &P,

--- a/minidump-processor/src/stackwalker/unwind.rs
+++ b/minidump-processor/src/stackwalker/unwind.rs
@@ -3,7 +3,7 @@
 
 use crate::process_state::StackFrame;
 use crate::{SymbolProvider, SystemInfo};
-use minidump::{MinidumpMemory, MinidumpModuleList};
+use minidump::{MinidumpModuleList, UnifiedMemory};
 
 /// A trait for things that can unwind to a caller.
 #[async_trait::async_trait]
@@ -13,7 +13,7 @@ pub trait Unwind {
         &self,
         callee: &StackFrame,
         grand_callee: Option<&StackFrame>,
-        stack_memory: Option<&MinidumpMemory<'_>>,
+        stack_memory: Option<UnifiedMemory<'_, '_>>,
         modules: &MinidumpModuleList,
         system_info: &SystemInfo,
         symbol_provider: &P,

--- a/minidump-processor/src/stackwalker/x86_unittest.rs
+++ b/minidump-processor/src/stackwalker/x86_unittest.rs
@@ -62,7 +62,7 @@ impl TestFixture {
             0,
             &options,
             &mut stack,
-            Some(&stack_memory),
+            Some(UnifiedMemory::Memory(&stack_memory)),
             &self.modules,
             &system_info,
             &symbolizer,

--- a/minidump/README.md
+++ b/minidump/README.md
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
         // Use `Default` to try to make progress when a stream is missing.
         // This is especially natural for MinidumpMemoryList because
         // everything needs to handle memory lookups failing anyway.
-        let mem = UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default());
+        let mem = dump.get_memory().unwrap_or_default();
 
         for thread in &threads.threads {
             let stack = thread.stack_memory(&mem);

--- a/minidump/README.md
+++ b/minidump/README.md
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
         // Use `Default` to try to make progress when a stream is missing.
         // This is especially natural for MinidumpMemoryList because
         // everything needs to handle memory lookups failing anyway.
-        let mem = dump.get_stream::<MinidumpMemoryList>().unwrap_or_default();
+        let mem = UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default());
 
         for thread in &threads.threads {
             let stack = thread.stack_memory(&mem);

--- a/minidump/src/lib.rs
+++ b/minidump/src/lib.rs
@@ -49,7 +49,7 @@
 //!         // Use `Default` to try to make progress when a stream is missing.
 //!         // This is especially natural for MinidumpMemoryList because
 //!         // everything needs to handle memory lookups failing anyway.
-//!         let mem = dump.get_stream::<MinidumpMemoryList>().unwrap_or_default();
+//!         let mem = UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default());
 //!
 //!         for thread in &threads.threads {
 //!             let stack = thread.stack_memory(&mem);

--- a/minidump/src/lib.rs
+++ b/minidump/src/lib.rs
@@ -49,7 +49,7 @@
 //!         // Use `Default` to try to make progress when a stream is missing.
 //!         // This is especially natural for MinidumpMemoryList because
 //!         // everything needs to handle memory lookups failing anyway.
-//!         let mem = UnifiedMemoryList::Memory(dump.get_stream::<MinidumpMemoryList>().unwrap_or_default());
+//!         let mem = dump.get_memory().unwrap_or_default();
 //!
 //!         for thread in &threads.threads {
 //!             let stack = thread.stack_memory(&mem);

--- a/minidump/tests/test_minidump.rs
+++ b/minidump/tests/test_minidump.rs
@@ -253,9 +253,10 @@ fn test_thread_list() {
     let thread_list = dump.get_stream::<MinidumpThreadList<'_>>().unwrap();
     let system_info = dump.get_stream::<MinidumpSystemInfo>().unwrap();
     let misc_info = dump.get_stream::<MinidumpMiscInfo>().ok();
-    let memory_list = dump
-        .get_stream::<MinidumpMemoryList<'_>>()
-        .unwrap_or_default();
+    let memory_list = UnifiedMemoryList::Memory(
+        dump.get_stream::<MinidumpMemoryList<'_>>()
+            .unwrap_or_default(),
+    );
 
     let threads = &thread_list.threads;
     assert_eq!(threads.len(), 2);

--- a/minidump/tests/test_minidump.rs
+++ b/minidump/tests/test_minidump.rs
@@ -253,10 +253,7 @@ fn test_thread_list() {
     let thread_list = dump.get_stream::<MinidumpThreadList<'_>>().unwrap();
     let system_info = dump.get_stream::<MinidumpSystemInfo>().unwrap();
     let misc_info = dump.get_stream::<MinidumpMiscInfo>().ok();
-    let memory_list = UnifiedMemoryList::Memory(
-        dump.get_stream::<MinidumpMemoryList<'_>>()
-            .unwrap_or_default(),
-    );
+    let memory_list = dump.get_memory().unwrap_or_default();
 
     let threads = &thread_list.threads;
     assert_eq!(threads.len(), 2);


### PR DESCRIPTION
...to abstract over memory streams and migrate all APIs to using them.

This makes rust-minidump work properly with modern "builtin" windows minidumps which only provide Memory64List. To see such a minidump: go to crash monitor, select an exe, right-click, "Create dump file". The resulting file will fail to stackwalk/analyze anything due to lack of memory.

This is an *enormous* breaking change to the primary `minidump` APIs, although minidump-processor's API I think works just as well. A second pass on docs might be worthwhile. Also it might be worthwhile to add an API to rust-minidump that handles fetching these streams for you.

Note that because I unconditionally only use the 64-bit stream over the 32-bit one if both exist, this will regress results if you specifically:

* Have both MemoryList streams defined
* The 64-bit one is junk and all the real values are in the 32-bit one