### PR TITLE
Make `minidump-common::format` structs writable through `scroll`.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,8 @@
 <!-- next-header -->
 # Next Version
 
+* Make all `minidump-common::format` structs writable with `scroll`.
+
 # Version 0.15.2 (2022-12-07)
 
 * Updated the num-range crate, further reducing the number of dependencies

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -372,7 +372,7 @@ pub struct MINIDUMP_MODULE {
 /// This struct matches the [Microsoft struct][msdn] of the same name.
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_unloaded_module
-#[derive(Debug, Clone, Default, Pread, SizeWith)]
+#[derive(Debug, Clone, Default, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_UNLOADED_MODULE {
     /// The base address of the executable image in memory (when it was loaded).
     pub base_of_image: u64,
@@ -659,7 +659,7 @@ impl<'a> scroll::ctx::TryFromCtx<'a, Endian> for CV_INFO_ELF {
 }
 
 /// Obsolete debug record type defined in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct IMAGE_DEBUG_MISC {
     pub data_type: u32,
     pub length: u32,
@@ -921,7 +921,7 @@ pub struct XMM_SAVE_AREA32 {
 ///
 /// This is defined as an anonymous struct inside an anonymous union in
 /// the x86-64 CONTEXT struct in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct SSE_REGISTERS {
     pub header: [u128; 2],
     pub legacy: [u128; 8],
@@ -1120,7 +1120,7 @@ pub struct CONTEXT_ARM64_OLD {
 /// NOTE: if you ever decide to try to make this repr(C) and get really clever,
 /// note that microsoft aligns this to 16 (and as of this writing, rust does
 /// not consistently aling u128 as such).
-#[derive(Debug, Default, Clone, Pread, SizeWith)]
+#[derive(Debug, Default, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CONTEXT_ARM64 {
     pub context_flags: u32,
@@ -1159,7 +1159,7 @@ impl Arm64RegisterNumbers {
 }
 
 /// MIPS floating point state
-#[derive(Debug, Default, Clone, Pread, SizeWith)]
+#[derive(Debug, Default, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FLOATING_SAVE_AREA_MIPS {
     pub regs: [u64; 32],
@@ -1170,7 +1170,7 @@ pub struct FLOATING_SAVE_AREA_MIPS {
 /// A MIPS CPU context
 ///
 /// This is a Breakpad extension, as there is no definition of `CONTEXT` for MIPS in WinNT.h.
-#[derive(Debug, Default, Clone, Pread, SizeWith)]
+#[derive(Debug, Default, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CONTEXT_MIPS {
     pub context_flags: u32,
@@ -1227,7 +1227,7 @@ impl MipsRegisterNumbers {
 }
 
 /// PPC floating point state
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FLOATING_SAVE_AREA_PPC {
     pub fpregs: [u64; 32],
@@ -1236,7 +1236,7 @@ pub struct FLOATING_SAVE_AREA_PPC {
 }
 
 /// PPC vector state
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct VECTOR_SAVE_AREA_PPC {
     pub save_vr: [u128; 32],
@@ -1249,7 +1249,7 @@ pub struct VECTOR_SAVE_AREA_PPC {
 /// A PPC CPU context
 ///
 /// This is a Breakpad extension, as there is no definition of `CONTEXT` for PPC in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CONTEXT_PPC {
     pub context_flags: u32,
@@ -1276,7 +1276,7 @@ pub enum PpcRegisterNumbers {
 /// A PPC64 CPU context
 ///
 /// This is a Breakpad extension, as there is no definition of `CONTEXT` for PPC64 in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CONTEXT_PPC64 {
     pub context_flags: u64,
@@ -1300,7 +1300,7 @@ pub enum Ppc64RegisterNumbers {
 }
 
 /// SPARC floating point state
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FLOATING_SAVE_AREA_SPARC {
     pub regs: [u64; 32],
@@ -1311,7 +1311,7 @@ pub struct FLOATING_SAVE_AREA_SPARC {
 /// A SPARC CPU context
 ///
 /// This is a Breakpad extension, as there is no definition of `CONTEXT` for SPARC in WinNT.h.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CONTEXT_SPARC {
     pub context_flags: u32,
@@ -1403,7 +1403,7 @@ pub struct CPU_INFORMATION {
 ///
 /// This struct matches the definition of the struct of the same name from minidumpapiset.h,
 /// which is contained within the [`CPU_INFORMATION`] union.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct X86CpuInfo {
     pub vendor_id: [u32; 3],
     pub version_information: u32,
@@ -1412,7 +1412,7 @@ pub struct X86CpuInfo {
 }
 
 /// Arm-specific CPU information (Breakpad extension)
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct ARMCpuInfo {
     pub cpuid: u32,
     /// Hardware capabilities
@@ -1425,7 +1425,7 @@ pub struct ARMCpuInfo {
 ///
 /// This struct matches the definition of the struct of the same name from minidumpapiset.h,
 /// which is contained within the [`CPU_INFORMATION`] union.
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct OtherCpuInfo {
     pub processor_features: [u64; 2],
 }
@@ -1816,7 +1816,7 @@ bitflags! {
 /// This struct matches the [Microsoft struct][msdn] of the same name.
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_info_list
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_MEMORY_INFO_LIST {
     /// The size of this header
     pub size_of_header: u32,
@@ -1831,7 +1831,7 @@ pub struct MINIDUMP_MEMORY_INFO_LIST {
 /// This struct matches the [Microsoft struct][msdn] of the same name.
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_info
-#[derive(Debug, Clone, PartialEq, Eq, Pread, SizeWith)]
+#[derive(Debug, Clone, PartialEq, Eq, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_MEMORY_INFO {
     /// The base address of the region of pages
     pub base_address: u64,
@@ -1930,7 +1930,7 @@ bitflags! {
 /// Taken from the definition in Breakpad's [minidump_format.h][fmt].
 ///
 /// [fmt]: https://chromium.googlesource.com/breakpad/breakpad/+/88d8114fda3e4a7292654bd6ac0c34d6c88a8121/src/google_breakpad/common/minidump_format.h#998
-#[derive(Debug, Clone, Pread, SizeWith)]
+#[derive(Debug, Clone, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_ASSERTION_INFO {
     /// The assertion that failed, as a 0-terminated UTF16-LE string
     pub expression: [u16; 128],
@@ -2055,7 +2055,7 @@ impl<'a> scroll::ctx::TryFromCtx<'a, Endian> for MINIDUMP_UTF8_STRING {
 /// A key-value pair.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpSimpleStringDictionaryEntry.html>
-#[derive(Clone, Debug, Pread, SizeWith)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_SIMPLE_STRING_DICTIONARY_ENTRY {
     /// RVA of a MinidumpUTF8String containing the key of a key-value pair.
     pub key: RVA,
@@ -2066,7 +2066,7 @@ pub struct MINIDUMP_SIMPLE_STRING_DICTIONARY_ENTRY {
 /// A list of key-value pairs.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpSimpleStringDictionary.html>
-#[derive(Clone, Debug, Pread)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_SIMPLE_STRING_DICTIONARY {
     /// The number of key-value pairs present.
     pub count: u32,
@@ -2075,7 +2075,7 @@ pub struct MINIDUMP_SIMPLE_STRING_DICTIONARY {
 /// A list of RVA pointers.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpRVAList.html>
-#[derive(Clone, Debug, Pread)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_RVA_LIST {
     /// The number of pointers present.
     pub count: u32,
@@ -2084,7 +2084,7 @@ pub struct MINIDUMP_RVA_LIST {
 /// A typed annotation object.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpAnnotation.html>
-#[derive(Clone, Debug, Pread)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_ANNOTATION {
     /// RVA of a MinidumpUTF8String containing the name of the annotation.
     pub name: RVA,
@@ -2125,7 +2125,7 @@ impl MINIDUMP_ANNOTATION {
 /// or not.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpModuleCrashpadInfo.html>
-#[derive(Clone, Debug, Pread)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_MODULE_CRASHPAD_INFO {
     /// The structure’s version number.
     ///
@@ -2172,7 +2172,7 @@ impl MINIDUMP_MODULE_CRASHPAD_INFO {
 /// module carried within a minidump file.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpModuleCrashpadInfoLink.html>
-#[derive(Clone, Debug, Pread, SizeWith)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_MODULE_CRASHPAD_INFO_LINK {
     /// A link to a MINIDUMP_MODULE structure in the module list stream.
     ///
@@ -2200,7 +2200,7 @@ pub struct MINIDUMP_MODULE_CRASHPAD_INFO_LINK {
 /// `MinidumpModuleCrashpadInfo` structure.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpModuleCrashpadInfoList.html>
-#[derive(Clone, Debug, Pread)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_MODULE_CRASHPAD_INFO_LIST {
     /// The number of key-value pairs present.
     pub count: u32,
@@ -2215,7 +2215,7 @@ pub struct MINIDUMP_MODULE_CRASHPAD_INFO_LIST {
 /// or not.
 ///
 /// See <https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpCrashpadInfo.html>
-#[derive(Clone, Debug, Pread, SizeWith)]
+#[derive(Clone, Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_CRASHPAD_INFO {
     /// The structure’s version number.
     ///
@@ -2258,7 +2258,7 @@ impl MINIDUMP_CRASHPAD_INFO {
 ///
 /// This is the format of the [`MINIDUMP_STREAM_TYPE::MozMacosCrashInfoStream`]. The individual
 /// [`MINIDUMP_MAC_CRASH_INFO_RECORD`] entries follow this header in the stream.
-#[derive(Debug, Pread, SizeWith)]
+#[derive(Debug, Pread, Pwrite, SizeWith)]
 pub struct MINIDUMP_MAC_CRASH_INFO {
     pub stream_type: u32,
     /// The number of [`MINIDUMP_MAC_CRASH_INFO_RECORD`]s.


### PR DESCRIPTION
As far as I can tell, there was no reason for these structs to not implement `Pwrite`. This is needed for https://github.com/rust-minidump/minidump-writer/issues/8.