### PR TITLE
Add additional details about the circumstances around possible bitflip

### DIFF
--- a/minidump-processor/json-schema.md
+++ b/minidump-processor/json-schema.md
@@ -155,8 +155,12 @@ anyway.
            "was_non_canonical": <bool>,
            /// Whether the bit-flipped address is null.
            "is_null": <bool>,
-           /// Whether any poison registers values were found in registers.
-           /// This is only set when `is_null` is true.
+           /// Whether the original address was fairly low.
+           /// This is only set if `is_null` is true, and may indicate that a
+           /// bit flip didn't occur (low values could be the result of many
+           /// things).
+           "was_low": <bool>,
+           /// Whether any poison register values were found.
            "poison_registers": <bool>,
            /// How many registers containing values near the bit-flip-corrected address.
            /// This is only set for corrected addresses which are sufficiently

--- a/minidump-processor/json-schema.md
+++ b/minidump-processor/json-schema.md
@@ -30,6 +30,7 @@ Features are grouped under three families which can be used for bulk enabling:
 Standard JSON types apply, which we will use as follows:
 
 * `<u32>` (unsigned 32-bit integer)
+* `<f32>` (IEEE 32-bit floating-point)
 * `<bool>`
 * `<string>`
 * `<array>`
@@ -146,7 +147,25 @@ anyway.
     /// A list of addresses that could have been the actual address the program
     /// wanted to access, but which were changed by a bit-flip.
     "possible_bit_flips": [
-      <hexstring>
+      {
+        "address": <hexstring>,
+        /// Flags related to the calculation of confidence in a bit-flip.
+        "details": {
+           /// Whether the original address was non-canonical.
+           "was_non_canonical": <bool>,
+           /// Whether the bit-flipped address is null.
+           "is_null": <bool>,
+           /// Whether any poison registers values were found in registers.
+           /// This is only set when `is_null` is true.
+           "poison_registers": <bool>,
+           /// How many registers containing values near the bit-flip-corrected address.
+           /// This is only set for corrected addresses which are sufficiently
+           /// high to avoid false positives with (likely) low values.
+           "nearby_registers": <u32>
+        },
+        /// The calculated confidence value in the bit-flip-corrected address.
+        "confidence": <f32>
+      }
     ],
 
     // The thread id of the thread that caused the crash (or requested the minidump).

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -4,6 +4,7 @@
 //! The state of a process.
 
 use std::borrow::{Borrow, Cow};
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io;
 use std::io::prelude::*;
@@ -12,7 +13,7 @@ use std::time::SystemTime;
 use crate::op_analysis::MemoryAccess;
 use crate::system_info::SystemInfo;
 use crate::{FrameSymbolizer, SymbolStats};
-use minidump::system_info::Cpu;
+use minidump::system_info::PointerWidth;
 use minidump::*;
 use minidump_common::utils::basename;
 use serde_json::json;
@@ -37,6 +38,64 @@ pub enum FrameTrust {
     /// Given as instruction pointer in a context.
     Context,
 }
+
+#[derive(Default)]
+struct SerializationContext {
+    pub pointer_width: Option<PointerWidth>,
+}
+
+std::thread_local! {
+    static SERIALIZATION_CONTEXT: RefCell<SerializationContext> = Default::default();
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(into = "String")]
+pub struct Address(pub u64);
+
+impl From<u64> for Address {
+    fn from(v: u64) -> Self {
+        Address(v)
+    }
+}
+
+impl From<Address> for u64 {
+    fn from(a: Address) -> Self {
+        a.0
+    }
+}
+
+impl From<Address> for String {
+    fn from(a: Address) -> Self {
+        a.to_string()
+    }
+}
+
+impl std::ops::Deref for Address {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Address {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::fmt::Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let pointer_width = SERIALIZATION_CONTEXT
+            .with(|ctx| ctx.borrow().pointer_width.unwrap_or(PointerWidth::Unknown));
+        match pointer_width {
+            PointerWidth::Bits32 => write!(f, "{:#010x}", self.0),
+            _ => write!(f, "{:#018x}", self.0),
+        }
+    }
+}
+
+pub type AddressOffset = Address;
 
 #[derive(Debug, Clone)]
 pub enum CallingConvention {
@@ -279,7 +338,7 @@ pub struct ExceptionInfo {
     /// caused the crash. For data access errors this will be the data address
     /// that caused the fault. For code errors, this will be the address of the
     /// instruction that caused the fault.
-    pub address: u64,
+    pub address: Address,
     /// In certain circumstances, the previous `address` member may report a sub-optimal value
     /// for debugging purposes. If instruction analysis is able to successfully determine a
     /// more helpful value, it will be reported here.
@@ -291,7 +350,7 @@ pub struct ExceptionInfo {
     /// Possible valid addresses which are one flipped bit away from the crashing address or adjusted address.
     ///
     /// The original address was possibly the result of faulty hardware, alpha particles, etc.
-    pub possible_bit_flips: Vec<u64>,
+    pub possible_bit_flips: Vec<PossibleBitFlip>,
 }
 
 /// Info about a memory address that was adjusted from its reported value
@@ -305,9 +364,163 @@ pub struct ExceptionInfo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AdjustedAddress {
     /// The original access was an Amd64 "non-canonical" address; actual address is provided here.
-    NonCanonical(u64),
+    NonCanonical(Address),
     /// The base pointer was null; offset from base is provided here.
-    NullPointerWithOffset(u64),
+    NullPointerWithOffset(AddressOffset),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct BitFlipDetails {
+    /// The bit flip caused a non-canonical address access.
+    pub was_non_canonical: bool,
+    /// The corrected address is null.
+    pub is_null: bool,
+    /// There are poison patterns in one or more registers.
+    ///
+    /// This is currently only set if is_null is set (as that's the only case we use in calculating
+    /// confidence).
+    pub poison_registers: bool,
+    /// The number of registers near the corrected address.
+    ///
+    /// This will only be populated for sufficiently high addresses (to avoid high false positive
+    /// rates).
+    pub nearby_registers: u32,
+}
+
+mod confidence {
+    /* The hat from which these numbers are drawn.
+           .~~~~`\~~\
+          ;       ~~ \
+          |           ;
+      ,--------,______|---.
+     /          \-----`    \
+     `.__________`-_______-'
+    */
+
+    const HIGH: f32 = 0.90;
+    const MEDIUM: f32 = 0.50;
+    const LOW: f32 = 0.25;
+
+    pub fn combine(values: &[f32]) -> f32 {
+        1.0f32 - values.iter().map(|v| 1.0f32 - v).product::<f32>()
+    }
+
+    // TODO: do we want this at all, vs Option<f32> for confidence?
+    // The only problem is there may not be a good way to display this (i.e. omitting a confidence
+    // would potentially make those seem _stronger_).
+    pub const BASELINE: f32 = LOW;
+
+    pub const NON_CANONICAL: f32 = HIGH;
+    pub const NULL: f32 = MEDIUM;
+    pub const NULL_POISON: f32 = LOW;
+    pub const NEARBY_REGISTER: f32 = MEDIUM;
+    pub const NEARBY_REGISTER_SCALE: f32 = 0.05;
+}
+
+impl BitFlipDetails {
+    /// Calculate a confidence level between 0 and 1 pertaining to the bit flip likelihood.
+    pub fn confidence(&self) -> f32 {
+        use confidence::*;
+        let mut values = Vec::with_capacity(4);
+        values.push(BASELINE);
+
+        if self.was_non_canonical {
+            values.push(NON_CANONICAL);
+        }
+
+        if self.is_null {
+            if self.poison_registers {
+                values.push(NULL_POISON);
+            } else {
+                values.push(NULL);
+            }
+        }
+
+        if self.nearby_registers > 0 {
+            let nearby = std::cmp::min(self.nearby_registers, 4);
+            values.push(NEARBY_REGISTER + NEARBY_REGISTER_SCALE * nearby as f32);
+        }
+
+        combine(&values)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct PossibleBitFlip {
+    /// The un-bit-flipped (potentially correct) address.
+    pub address: Address,
+    /// Heuristics related to the determination of the bit flip.
+    pub details: BitFlipDetails,
+    /// A confidence level for the bit flip, derived from the details.
+    pub confidence: Option<f32>,
+}
+
+/// The maximum distance between addresses to consider them "nearby" when calculating bit flip
+/// heuristics with regard to register contents.
+const NEARBY_REGISTER_DISTANCE: u64 = 1 << 12;
+
+impl PossibleBitFlip {
+    pub fn new(address: u64) -> Self {
+        PossibleBitFlip {
+            address: address.into(),
+            details: Default::default(),
+            confidence: None,
+        }
+    }
+
+    pub fn calculate_heuristics(
+        &mut self,
+        was_non_canonical: bool,
+        context: Option<&MinidumpContext>,
+    ) {
+        self.details.is_null = self.address.0 == 0;
+        self.details.was_non_canonical = was_non_canonical;
+
+        self.details.nearby_registers = 0;
+        self.details.poison_registers = false;
+        if let Some(context) = context {
+            let register_size = context.register_size();
+
+            let is_repeated = match register_size {
+                2 => |addr: u64| addr == (addr & 0xff) * 0x0101,
+                4 => |addr: u64| addr == (addr & 0xff) * 0x01010101,
+                8 => |addr: u64| addr == (addr & 0xff) * 0x0101010101010101,
+                other => {
+                    tracing::warn!("unsupported register size: {other}");
+                    |_| false
+                }
+            };
+
+            // Don't calculate nearby registers for low addresses, there will be a high false
+            // positive rate.
+            let should_calculate_nearby_registers = self.address.0 > NEARBY_REGISTER_DISTANCE * 2;
+
+            for (_, addr) in context.valid_registers() {
+                if should_calculate_nearby_registers
+                    && self.address.0.abs_diff(addr) <= NEARBY_REGISTER_DISTANCE
+                {
+                    self.details.nearby_registers += 1;
+                }
+
+                if self.details.is_null && !self.details.poison_registers && is_repeated(addr) {
+                    // Poison patterns from
+                    // https://searchfox.org/mozilla-central/rev/3002762e41363de8ee9ca80196d55e79651bcb6b/js/src/util/Poison.h#52
+                    //
+                    // 0xA5 from xmalloc
+                    // 0xe5 from #808
+                    match (addr & 0xff) as u8 {
+                        0x2b | 0x2d | 0x2f | 0x49 | 0x4b | 0x4d | 0x4f | 0x6b | 0x8b | 0x9b
+                        | 0x9f | 0xa5 | 0xbb | 0xcc | 0xcd | 0xce | 0xdb | 0xe5 => {
+                            self.details.poison_registers = true;
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+
+        self.confidence = Some(self.details.confidence());
+    }
 }
 
 /// The state of a process as recorded by a `Minidump`.
@@ -666,6 +879,8 @@ impl ProcessState {
     }
 
     fn print_internal<T: Write>(&self, f: &mut T, brief: bool) -> io::Result<()> {
+        self.set_print_context();
+
         writeln!(f, "Operating system: {}", self.system_info.os.long_name())?;
         if let Some(ref ver) = self.system_info.format_os_version() {
             writeln!(f, "                  {ver}")?;
@@ -697,17 +912,17 @@ impl ProcessState {
             writeln!(f, "Crash reason:  {}", crash_info.reason)?;
 
             if let Some(adjusted_address) = &crash_info.adjusted_address {
-                writeln!(f, "Crash address: {:#x} **", crash_info.address)?;
+                writeln!(f, "Crash address: {} **", crash_info.address)?;
                 match adjusted_address {
                     AdjustedAddress::NonCanonical(address) => {
-                        writeln!(f, "    ** Non-canonical address detected: {address:#x}")?
+                        writeln!(f, "    ** Non-canonical address detected: {address}")?
                     }
                     AdjustedAddress::NullPointerWithOffset(offset) => {
-                        writeln!(f, "    ** Null pointer detected with offset: {offset:#x}")?
+                        writeln!(f, "    ** Null pointer detected with offset: {offset}")?
                     }
                 }
             } else {
-                writeln!(f, "Crash address: {:#x}", crash_info.address)?;
+                writeln!(f, "Crash address: {}", crash_info.address)?;
             }
 
             if let Some(ref crashing_instruction_str) = crash_info.instruction_str {
@@ -718,7 +933,7 @@ impl ProcessState {
                 if !memory_accesses.is_empty() {
                     writeln!(f, "Memory accessed by instruction:")?;
                     for (idx, access) in memory_accesses.iter().enumerate() {
-                        writeln!(f, "  {}. Address: 0x{:016x}", idx, access.address)?;
+                        writeln!(f, "  {idx}. Address: {}", Address(access.address))?;
                         if let Some(size) = access.size {
                             writeln!(f, "     Size: {size}")?;
                         } else {
@@ -732,8 +947,24 @@ impl ProcessState {
 
             if !crash_info.possible_bit_flips.is_empty() {
                 writeln!(f, "Crashing address may be the result of a flipped bit:")?;
-                for (idx, addr) in crash_info.possible_bit_flips.iter().enumerate() {
-                    writeln!(f, "  {idx}. Valid address: 0x{addr:016x}")?;
+                let mut bit_flips_with_confidence = crash_info
+                    .possible_bit_flips
+                    .iter()
+                    .map(|b| (b.confidence.unwrap_or_default(), b))
+                    .collect::<Vec<_>>();
+                // Sort by confidence (descending), then address (ascending).
+                bit_flips_with_confidence.sort_unstable_by(|(conf_a, bf_a), (conf_b, bf_b)| {
+                    conf_a
+                        .total_cmp(conf_b)
+                        .reverse()
+                        .then_with(|| bf_a.address.cmp(&bf_b.address))
+                });
+                for (idx, (confidence, b)) in bit_flips_with_confidence.iter().enumerate() {
+                    writeln!(
+                        f,
+                        "  {idx}. Valid address: {addr} ({confidence:.3})",
+                        addr = b.address
+                    )?;
                 }
             }
         } else {
@@ -911,10 +1142,13 @@ Unknown streams encountered:
     pub fn print_json<T: Write>(&self, f: &mut T, pretty: bool) -> Result<(), serde_json::Error> {
         // See ../json-schema.md for details on this format.
 
+        self.set_print_context();
+
         let sys = &self.system_info;
 
-        // Curry self for use in `map`
-        let json_hex = |val: u64| -> String { self.json_hex(val) };
+        fn json_hex(address: u64) -> String {
+            Address(address).to_string()
+        }
 
         let mut output = json!({
             // Currently unused, we either produce no output or successful output.
@@ -933,16 +1167,16 @@ Unknown streams encountered:
             },
             "crash_info": {
                 "type": self.exception_info.as_ref().map(|info| info.reason).map(|reason| reason.to_string()),
-                "address": self.exception_info.as_ref().map(|info| info.address).map(json_hex),
+                "address": self.exception_info.as_ref().map(|info| info.address),
                 "adjusted_address": self.exception_info.as_ref().map(|info| {
                     info.adjusted_address.as_ref().map(|adjusted| match adjusted {
                         AdjustedAddress::NonCanonical(address) => json!({
                             "kind": "non-canonical",
-                            "address": json_hex(*address),
+                            "address": address,
                         }),
                         AdjustedAddress::NullPointerWithOffset(offset) => json!({
                             "kind": "null-pointer",
-                            "offset": json_hex(*offset),
+                            "offset": offset,
                         }),
                     })
                 }),
@@ -958,8 +1192,7 @@ Unknown streams encountered:
                     })
                 }),
                 "possible_bit_flips": self.exception_info.as_ref().and_then(|info| {
-                    (!info.possible_bit_flips.is_empty())
-                        .then(|| info.possible_bit_flips.iter().copied().map(json_hex).collect::<Vec<_>>())
+                    (!info.possible_bit_flips.is_empty()).then_some(&info.possible_bit_flips)
                 }),
                 // thread index | null
                 "crashing_thread": self.requesting_thread,
@@ -1139,15 +1372,9 @@ Unknown streams encountered:
         }
     }
 
-    // Convert an integer to a hex string, with leading 0's for uniform width.
-    fn json_hex(&self, val: u64) -> String {
-        match self.system_info.cpu {
-            Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm | Cpu::Mips => {
-                format!("0x{val:08x}")
-            }
-            _ => {
-                format!("0x{val:016x}")
-            }
-        }
+    fn set_print_context(&self) {
+        SERIALIZATION_CONTEXT.with(|ctx| {
+            ctx.borrow_mut().pointer_width = Some(self.system_info.cpu.pointer_width());
+        });
     }
 }

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -447,147 +447,205 @@ where
     T: Deref<Target = [u8]> + 'a,
     P: SymbolProvider + Sync,
 {
-    options.check_deprecated_and_disabled();
+    let info = MinidumpInfo::new(dump, options)?;
 
-    // Get the evil JSON file (thread names, module certificates, etc)
-    let evil = options
-        .evil_json
-        .and_then(evil::handle_evil)
-        .unwrap_or_default();
+    let mut exception_details = info.get_exception_details();
 
-    // Thread list is required for processing.
-    let thread_list = dump
-        .get_stream::<MinidumpThreadList>()
-        .or(Err(ProcessError::MissingThreadList))?;
+    if let Some(details) = &mut exception_details {
+        info.check_for_bitflips(details);
+    }
+    info.into_process_state(dump, symbol_provider, exception_details)
+        .await
+}
 
-    let num_threads = thread_list.threads.len() as u64;
-    if let Some(reporter) = options.stat_reporter {
-        reporter.set_total_threads(num_threads);
+struct MinidumpInfo<'a> {
+    options: ProcessorOptions<'a>,
+    evil: crate::evil::Evil,
+    thread_list: MinidumpThreadList<'a>,
+    thread_names: MinidumpThreadNames,
+    dump_system_info: MinidumpSystemInfo,
+    linux_standard_base: Option<LinuxStandardBase>,
+    system_info: SystemInfo,
+    mac_crash_info: Option<Vec<RawMacCrashInfo>>,
+    misc_info: Option<MinidumpMiscInfo>,
+    dump_thread_id: Option<u32>,
+    requesting_thread_id: Option<u32>,
+    modules: MinidumpModuleList,
+    unloaded_modules: MinidumpUnloadedModuleList,
+    memory_list: UnifiedMemoryList<'a>,
+    /*
+    memory_info_list: Option<MinidumpMemoryInfoList<'a>>,
+    linux_maps: Option<MinidumpLinuxMaps<'a>>,
+    */
+    memory_info: UnifiedMemoryInfoList<'a>,
+    exception: Option<MinidumpException<'a>>,
+    //exception_details: Option<ExceptionDetails<'a>>,
+}
+
+impl<'a> MinidumpInfo<'a> {
+    pub fn new<T: Deref<Target = [u8]> + 'a>(
+        dump: &'a Minidump<'a, T>,
+        options: ProcessorOptions<'a>,
+    ) -> Result<Self, ProcessError> {
+        options.check_deprecated_and_disabled();
+
+        // Get the evil JSON file (thread names, module certificates, etc)
+        let evil = options
+            .evil_json
+            .and_then(evil::handle_evil)
+            .unwrap_or_default();
+
+        // Thread list is required for processing.
+        let thread_list = dump
+            .get_stream::<MinidumpThreadList>()
+            .or(Err(ProcessError::MissingThreadList))?;
+
+        let num_threads = thread_list.threads.len() as u64;
+        if let Some(reporter) = options.stat_reporter {
+            reporter.set_total_threads(num_threads);
+        }
+
+        // Try to get thread names, but it's only a nice-to-have.
+        let thread_names = dump
+            .get_stream::<MinidumpThreadNames>()
+            .unwrap_or_else(|_| MinidumpThreadNames::default());
+
+        // System info is required for processing.
+        let dump_system_info = dump
+            .get_stream::<MinidumpSystemInfo>()
+            .or(Err(ProcessError::MissingSystemInfo))?;
+
+        let (os_version, os_build) = dump_system_info.os_parts();
+
+        let linux_standard_base = dump.get_stream::<MinidumpLinuxLsbRelease>().ok();
+        let linux_cpu_info = dump
+            .get_stream::<MinidumpLinuxCpuInfo>()
+            .unwrap_or_default();
+        let _linux_environ = dump.get_stream::<MinidumpLinuxEnviron>().ok();
+        let _linux_proc_status = dump.get_stream::<MinidumpLinuxProcStatus>().ok();
+
+        // Extract everything we care about from linux streams here.
+        // We don't eagerly process them in the minidump crate because there's just
+        // tons of random information in there and it's not obvious what anyone
+        // would care about. So just providing an iterator and letting minidump-processor
+        // pull out the things it cares about is simple and effective.
+
+        let cpu_microcode_version = get_microcode_version(&linux_cpu_info, &evil);
+
+        let linux_standard_base = linux_standard_base.map(|linux_standard_base| {
+            let mut lsb = LinuxStandardBase::default();
+            for (key, val) in linux_standard_base.iter() {
+                match key.as_bytes() {
+                    b"DISTRIB_ID" | b"ID" => lsb.id = val.to_string_lossy().into_owned(),
+                    b"DISTRIB_RELEASE" | b"VERSION_ID" => {
+                        lsb.release = val.to_string_lossy().into_owned()
+                    }
+                    b"DISTRIB_CODENAME" | b"VERSION_CODENAME" => {
+                        lsb.codename = val.to_string_lossy().into_owned()
+                    }
+                    b"DISTRIB_DESCRIPTION" | b"PRETTY_NAME" => {
+                        lsb.description = val.to_string_lossy().into_owned()
+                    }
+                    _ => {}
+                }
+            }
+            lsb
+        });
+
+        let cpu_info = dump_system_info
+            .cpu_info()
+            .map(|string| string.into_owned());
+
+        let system_info = SystemInfo {
+            os: dump_system_info.os,
+            os_version: Some(os_version),
+            os_build,
+            cpu: dump_system_info.cpu,
+            cpu_info,
+            cpu_microcode_version,
+            cpu_count: dump_system_info.raw.number_of_processors as usize,
+        };
+
+        let mac_crash_info = dump
+            .get_stream::<MinidumpMacCrashInfo>()
+            .ok()
+            .map(|info| info.raw);
+
+        let misc_info = dump.get_stream::<MinidumpMiscInfo>().ok();
+        // If Breakpad info exists in dump, get dump and requesting thread ids.
+        let breakpad_info = dump.get_stream::<MinidumpBreakpadInfo>();
+        let (dump_thread_id, requesting_thread_id) = if let Ok(info) = breakpad_info {
+            (info.dump_thread_id, info.requesting_thread_id)
+        } else {
+            (None, None)
+        };
+        // Get assertion
+        let modules = match dump.get_stream::<MinidumpModuleList>() {
+            Ok(module_list) => module_list,
+            // Just give an empty list, simplifies things.
+            Err(_) => MinidumpModuleList::new(),
+        };
+        let unloaded_modules = match dump.get_stream::<MinidumpUnloadedModuleList>() {
+            Ok(module_list) => module_list,
+            // Just give an empty list, simplifies things.
+            Err(_) => MinidumpUnloadedModuleList::new(),
+        };
+        let memory_list = dump.get_memory().unwrap_or_default();
+        let memory_info_list = dump.get_stream::<MinidumpMemoryInfoList>().ok();
+        let linux_maps = dump.get_stream::<MinidumpLinuxMaps>().ok();
+        let memory_info =
+            UnifiedMemoryInfoList::new(memory_info_list, linux_maps).unwrap_or_default();
+
+        // Get exception info if it exists.
+        let exception = dump.get_stream::<MinidumpException>().ok();
+
+        Ok(MinidumpInfo {
+            options,
+            evil,
+            thread_list,
+            thread_names,
+            dump_system_info,
+            linux_standard_base,
+            system_info,
+            mac_crash_info,
+            misc_info,
+            dump_thread_id,
+            requesting_thread_id,
+            modules,
+            unloaded_modules,
+            memory_list,
+            /*
+            memory_info_list: Option<MinidumpMemoryInfoList<'a>>,
+            linux_maps: Option<MinidumpLinuxMaps<'a>>,
+            */
+            memory_info,
+            exception,
+            //exception_details: None,
+        })
     }
 
-    // Try to get thread names, but it's only a nice-to-have.
-    let thread_names = dump
-        .get_stream::<MinidumpThreadNames>()
-        .unwrap_or_else(|_| MinidumpThreadNames::default());
+    /// Get details about the minidump exception, if available.
+    pub fn get_exception_details(&self) -> Option<ExceptionDetails<'a>> {
+        let exception = self.exception.as_ref()?;
 
-    // System info is required for processing.
-    let dump_system_info = dump
-        .get_stream::<MinidumpSystemInfo>()
-        .or(Err(ProcessError::MissingSystemInfo))?;
+        let reason = exception.get_crash_reason(self.system_info.os, self.system_info.cpu);
+        let address = exception.get_crash_address(self.system_info.os, self.system_info.cpu);
 
-    let (os_version, os_build) = dump_system_info.os_parts();
-
-    let linux_standard_base = dump.get_stream::<MinidumpLinuxLsbRelease>().ok();
-    let linux_cpu_info = dump
-        .get_stream::<MinidumpLinuxCpuInfo>()
-        .unwrap_or_default();
-    let _linux_environ = dump.get_stream::<MinidumpLinuxEnviron>().ok();
-    let _linux_proc_status = dump.get_stream::<MinidumpLinuxProcStatus>().ok();
-
-    // Extract everything we care about from linux streams here.
-    // We don't eagerly process them in the minidump crate because there's just
-    // tons of random information in there and it's not obvious what anyone
-    // would care about. So just providing an iterator and letting minidump-processor
-    // pull out the things it cares about is simple and effective.
-
-    let cpu_microcode_version = get_microcode_version(&linux_cpu_info, &evil);
-
-    let linux_standard_base = linux_standard_base.map(|linux_standard_base| {
-        let mut lsb = LinuxStandardBase::default();
-        for (key, val) in linux_standard_base.iter() {
-            match key.as_bytes() {
-                b"DISTRIB_ID" | b"ID" => lsb.id = val.to_string_lossy().into_owned(),
-                b"DISTRIB_RELEASE" | b"VERSION_ID" => {
-                    lsb.release = val.to_string_lossy().into_owned()
-                }
-                b"DISTRIB_CODENAME" | b"VERSION_CODENAME" => {
-                    lsb.codename = val.to_string_lossy().into_owned()
-                }
-                b"DISTRIB_DESCRIPTION" | b"PRETTY_NAME" => {
-                    lsb.description = val.to_string_lossy().into_owned()
-                }
-                _ => {}
-            }
-        }
-        lsb
-    });
-
-    let cpu_info = dump_system_info
-        .cpu_info()
-        .map(|string| string.into_owned());
-
-    let system_info = SystemInfo {
-        os: dump_system_info.os,
-        os_version: Some(os_version),
-        os_build,
-        cpu: dump_system_info.cpu,
-        cpu_info,
-        cpu_microcode_version,
-        cpu_count: dump_system_info.raw.number_of_processors as usize,
-    };
-
-    let mac_crash_info = dump
-        .get_stream::<MinidumpMacCrashInfo>()
-        .ok()
-        .map(|info| info.raw);
-
-    let misc_info = dump.get_stream::<MinidumpMiscInfo>().ok();
-    // Process create time is optional.
-    let (process_id, process_create_time) = if let Some(misc_info) = misc_info.as_ref() {
-        (
-            misc_info.raw.process_id().cloned(),
-            misc_info.process_create_time(),
-        )
-    } else {
-        (None, None)
-    };
-    // If Breakpad info exists in dump, get dump and requesting thread ids.
-    let breakpad_info = dump.get_stream::<MinidumpBreakpadInfo>();
-    let (dump_thread_id, requesting_thread_id) = if let Ok(info) = breakpad_info {
-        (info.dump_thread_id, info.requesting_thread_id)
-    } else {
-        (None, None)
-    };
-    // Get assertion
-    let assertion = None;
-    let modules = match dump.get_stream::<MinidumpModuleList>() {
-        Ok(module_list) => module_list,
-        // Just give an empty list, simplifies things.
-        Err(_) => MinidumpModuleList::new(),
-    };
-    let unloaded_modules = match dump.get_stream::<MinidumpUnloadedModuleList>() {
-        Ok(module_list) => module_list,
-        // Just give an empty list, simplifies things.
-        Err(_) => MinidumpUnloadedModuleList::new(),
-    };
-    let memory_list = dump.get_memory().unwrap_or_default();
-    let memory_info_list = dump.get_stream::<MinidumpMemoryInfoList>().ok();
-    let linux_maps = dump.get_stream::<MinidumpLinuxMaps>().ok();
-    let memory_info = UnifiedMemoryInfoList::new(memory_info_list, linux_maps).unwrap_or_default();
-
-    // Get exception info if it exists.
-    let exception_stream = dump.get_stream::<MinidumpException>().ok();
-    let exception_ref = exception_stream.as_ref();
-
-    let mut exception_info: Option<crate::ExceptionInfo> = None;
-    let mut exception_context: Option<std::borrow::Cow<MinidumpContext>> = None;
-    let mut instruction_registers: BTreeSet<&'static str> = Default::default();
-
-    if let Some(exception) = exception_ref {
-        let reason = exception.get_crash_reason(system_info.os, system_info.cpu);
-        let address = exception.get_crash_address(system_info.os, system_info.cpu);
-
-        let stack_memory_ref = thread_list
+        let stack_memory_ref = self
+            .thread_list
             .get_thread(exception.get_crashing_thread_id())
-            .and_then(|thread| thread.stack_memory(&memory_list));
+            .and_then(|thread| thread.stack_memory(&self.memory_list));
 
-        exception_context = exception.context(&dump_system_info, misc_info.as_ref());
+        let context = exception.context(&self.dump_system_info, self.misc_info.as_ref());
+
+        let mut exception_info: Option<crate::ExceptionInfo> = None;
+        let mut instruction_registers: BTreeSet<&'static str> = Default::default();
 
         // If we have a context, we can attempt to analyze the crashing thread's instructions
-        if let Some(context) = &exception_context {
+        if let Some(context) = context.as_ref() {
             match crate::op_analysis::analyze_thread_context(
                 context,
-                &memory_list,
+                &self.memory_list,
                 stack_memory_ref,
             ) {
                 Ok(op_analysis) => {
@@ -597,7 +655,7 @@ where
                         .map(|offset| AdjustedAddress::NullPointerWithOffset(offset.into()))
                         .or_else(|| {
                             try_get_non_canonical_crash_address(
-                                &system_info,
+                                &self.system_info,
                                 memory_accesses,
                                 reason,
                                 address,
@@ -621,239 +679,285 @@ where
             }
         }
 
-        if exception_info.is_none() {
-            exception_info = Some(crate::ExceptionInfo {
-                reason,
-                address: address.into(),
-                adjusted_address: None,
-                instruction_str: None,
-                memory_accesses: None,
-                possible_bit_flips: Default::default(),
-            });
-        }
+        let info = exception_info.unwrap_or_else(|| crate::ExceptionInfo {
+            reason,
+            address: address.into(),
+            adjusted_address: None,
+            instruction_str: None,
+            memory_accesses: None,
+            possible_bit_flips: Default::default(),
+        });
+
+        Some(ExceptionDetails {
+            info,
+            context,
+            instruction_registers,
+        })
     }
 
-    // Check for bit-flips of the exception address
-    //
-    // Only check for bit-flips on 64-bit systems, as the large memory space makes false-positives
-    // less likely.
-    if system_info.cpu.pointer_width() == PointerWidth::Bits64 {
-        if let Some(info) = &mut exception_info {
-            use bitflip::BitRange;
-            let bit_flip_address = match &info.adjusted_address {
-                // Use the non canonical address if present.
-                Some(AdjustedAddress::NonCanonical(v)) => Some((v.0, BitRange::Amd64NonCanonical)),
-                // If we think the address is a null pointer with an offset, don't try bit flips.
-                Some(AdjustedAddress::NullPointerWithOffset(_)) => None,
-                // Try the crashing address if no adjustments have been made.
-                None => Some((
-                    info.address.0,
-                    if system_info.cpu != system_info::Cpu::X86_64 {
-                        BitRange::All
-                    } else {
-                        BitRange::Amd64Canononical
-                    },
-                )),
-            };
-            if let Some((address, bit_range)) = bit_flip_address {
-                let memory_op = bitflip::MemoryOperation::from_crash_reason(&info.reason);
-                info.possible_bit_flips = bitflip::try_bit_flips(
-                    address,
-                    None,
-                    bit_range,
-                    exception_context.as_deref(),
-                    &memory_info,
-                    memory_op,
-                );
-                if let Some(context) = exception_context.as_deref() {
-                    for reg in instruction_registers {
-                        if let Some(address) = context.get_register(reg) {
-                            info.possible_bit_flips.extend(bitflip::try_bit_flips(
-                                address,
-                                Some(reg),
-                                bit_range,
-                                exception_context.as_deref(),
-                                &memory_info,
-                                // We assume that a register that is causing a crash due to a flipped
-                                // bit has the same memory operation as the crash (i.e. we assume that
-                                // the base address, possibly combined with some offset, is still in
-                                // the same memory region).
-                                memory_op,
-                            ));
-                        }
+    /// Check for bit-flips of the exception address/instruction.
+    ///
+    /// Additional bit flip information will be added to `exception_details`.
+    pub fn check_for_bitflips(&self, exception_details: &mut ExceptionDetails<'a>) {
+        // Only check for bit-flips on 64-bit systems, as the large memory space makes
+        // false-positives less likely.
+        if self.system_info.cpu.pointer_width() != PointerWidth::Bits64 {
+            return;
+        }
+
+        let info = &mut exception_details.info;
+
+        use bitflip::BitRange;
+        let bit_flip_address = match &info.adjusted_address {
+            // Use the non canonical address if present.
+            Some(AdjustedAddress::NonCanonical(v)) => Some((v.0, BitRange::Amd64NonCanonical)),
+            // If we think the address is a null pointer with an offset, don't try bit flips.
+            Some(AdjustedAddress::NullPointerWithOffset(_)) => None,
+            // Try the crashing address if no adjustments have been made.
+            None => Some((
+                info.address.0,
+                if self.system_info.cpu != system_info::Cpu::X86_64 {
+                    BitRange::All
+                } else {
+                    BitRange::Amd64Canononical
+                },
+            )),
+        };
+        if let Some((address, bit_range)) = bit_flip_address {
+            let memory_op = bitflip::MemoryOperation::from_crash_reason(&info.reason);
+            info.possible_bit_flips = bitflip::try_bit_flips(
+                address,
+                None,
+                bit_range,
+                exception_details.context.as_deref(),
+                &self.memory_info,
+                memory_op,
+            );
+
+            // If we have an exception context, we can check the registers involved in the
+            // crashing instruction.
+            if let Some(context) = exception_details.context.as_deref() {
+                for reg in &exception_details.instruction_registers {
+                    if let Some(address) = context.get_register(reg) {
+                        info.possible_bit_flips.extend(bitflip::try_bit_flips(
+                            address,
+                            Some(reg),
+                            bit_range,
+                            Some(context),
+                            &self.memory_info,
+                            // We assume that a register that is causing a crash due to a flipped
+                            // bit has the same memory operation as the crash (i.e. we assume that
+                            // the base address, possibly combined with some offset, is still in
+                            // the same memory region).
+                            memory_op,
+                        ));
                     }
                 }
             }
         }
     }
 
-    let crashing_thread_id = exception_ref.map(|e| e.get_crashing_thread_id());
-
-    let exception_context =
-        exception_ref.and_then(|e| e.context(&dump_system_info, misc_info.as_ref()));
-
-    let mut requesting_thread = None;
-
-    let threads = thread_list
-        .threads
-        .iter()
-        .enumerate()
-        .map(|(i, thread)| {
-            let id = thread.raw.thread_id;
-
-            // If this is the thread that wrote the dump, skip processing it.
-            if dump_thread_id == Some(id) {
-                return CallStack::with_info(id, CallStackInfo::DumpThreadSkipped);
-            }
-
-            let thread_context = thread.context(&dump_system_info, misc_info.as_ref());
-            // If this thread requested the dump then try to use the exception
-            // context if it exists. (prefer the exception stream's thread id over
-            // the breakpad info stream's thread id.)
-            let context = if crashing_thread_id.or(requesting_thread_id) == Some(id) {
-                requesting_thread = Some(i);
-                exception_context.as_deref().or(thread_context.as_deref())
-            } else {
-                thread_context.as_deref()
-            };
-
-            let name = thread_names
-                .get_name(thread.raw.thread_id)
-                .map(|cow| cow.into_owned())
-                .or_else(|| evil.thread_names.get(&thread.raw.thread_id).cloned());
-
-            let (info, frames) = if let Some(context) = context {
-                let ctx = context.clone();
-                (
-                    CallStackInfo::Ok,
-                    vec![StackFrame::from_context(ctx, FrameTrust::Context)],
-                )
-            } else {
-                (CallStackInfo::MissingContext, vec![])
-            };
-
-            CallStack {
-                frames,
-                info,
-                thread_id: id,
-                thread_name: name,
-                last_error_value: thread.last_error(system_info.cpu, &memory_list),
-            }
-        })
-        .collect();
-
-    // Collect up info on unimplemented/unknown modules
-    let unknown_streams = dump.unknown_streams().collect();
-    let unimplemented_streams = dump.unimplemented_streams().collect();
-
-    // Get symbol stats from the symbolizer
-    let symbol_stats = symbol_provider.stats();
-
-    let mut state = ProcessState {
-        process_id,
-        time: SystemTime::UNIX_EPOCH + Duration::from_secs(dump.header.time_date_stamp as u64),
-        process_create_time,
-        cert_info: evil.certs,
-        exception_info,
-        assertion,
-        requesting_thread,
-        system_info,
-        linux_standard_base,
-        mac_crash_info,
-        threads,
-        modules,
-        unloaded_modules,
-        unknown_streams,
-        unimplemented_streams,
-        symbol_stats,
-    };
-
-    // Report the unwalked result
-    if let Some(reporter) = options.stat_reporter {
-        reporter.add_unwalked_result(&state);
-    }
-
+    pub async fn into_process_state<P, T>(
+        self,
+        dump: &Minidump<'a, T>,
+        symbol_provider: &P,
+        exception_details: Option<ExceptionDetails<'a>>,
+    ) -> Result<ProcessState, ProcessError>
+    where
+        T: Deref<Target = [u8]> + 'a,
+        P: SymbolProvider + Sync,
     {
-        let memory_list = &memory_list;
-        let modules = &state.modules;
-        let system_info = &state.system_info;
-        let unloaded_modules = &state.unloaded_modules;
-        let options = &options;
+        let crashing_thread_id = self.exception.as_ref().map(|e| e.get_crashing_thread_id());
 
-        futures_util::future::join_all(
-            state
-                .threads
-                .iter_mut()
-                .zip(thread_list.threads.iter())
-                .enumerate()
-                .map(|(i, (stack, thread))| async move {
-                    let mut stack_memory = thread.stack_memory(memory_list);
-                    // Always choose the memory region that is referenced by the context,
-                    // as the `exception_context` may refer to a different memory region than
-                    // the `thread_context`, which in turn would fail to stack walk.
-                    let stack_ptr = stack
-                        .frames
-                        .get(0)
-                        .map(|ctx_frame| ctx_frame.context.get_stack_pointer());
-                    if let Some(stack_ptr) = stack_ptr {
-                        let contains_stack_ptr = stack_memory
-                            .as_ref()
-                            .and_then(|memory| memory.get_memory_at_address::<u64>(stack_ptr))
-                            .is_some();
-                        if !contains_stack_ptr {
-                            stack_memory =
-                                memory_list.memory_at_address(stack_ptr).or(stack_memory);
-                        }
-                    }
+        let (exception_info, exception_context) = match exception_details {
+            Some(details) => (Some(details.info), details.context),
+            None => (None, None),
+        };
 
-                    stackwalker::walk_stack(
-                        i,
-                        options,
-                        stack,
-                        stack_memory,
-                        modules,
-                        system_info,
-                        symbol_provider,
+        let mut requesting_thread = None;
+
+        let threads = self
+            .thread_list
+            .threads
+            .iter()
+            .enumerate()
+            .map(|(i, thread)| {
+                let id = thread.raw.thread_id;
+
+                // If this is the thread that wrote the dump, skip processing it.
+                if self.dump_thread_id == Some(id) {
+                    return CallStack::with_info(id, CallStackInfo::DumpThreadSkipped);
+                }
+
+                let thread_context =
+                    thread.context(&self.dump_system_info, self.misc_info.as_ref());
+                // If this thread requested the dump then try to use the exception
+                // context if it exists. (prefer the exception stream's thread id over
+                // the breakpad info stream's thread id.)
+                let context = if crashing_thread_id.or(self.requesting_thread_id) == Some(id) {
+                    requesting_thread = Some(i);
+                    exception_context.as_deref().or(thread_context.as_deref())
+                } else {
+                    thread_context.as_deref()
+                };
+
+                let name = self
+                    .thread_names
+                    .get_name(thread.raw.thread_id)
+                    .map(|cow| cow.into_owned())
+                    .or_else(|| self.evil.thread_names.get(&thread.raw.thread_id).cloned());
+
+                let (info, frames) = if let Some(context) = context {
+                    let ctx = context.clone();
+                    (
+                        CallStackInfo::Ok,
+                        vec![StackFrame::from_context(ctx, FrameTrust::Context)],
                     )
-                    .await;
+                } else {
+                    (CallStackInfo::MissingContext, vec![])
+                };
 
-                    for frame in &mut stack.frames {
-                        // If the frame doesn't have a loaded module, try to find an unloaded module
-                        // that overlaps with its address range. The may be multiple, so record all
-                        // of them and the offsets this frame has in them.
-                        if frame.module.is_none() {
-                            let mut offsets = BTreeMap::new();
-                            for unloaded in unloaded_modules.modules_at_address(frame.instruction) {
-                                let offset = frame.instruction - unloaded.raw.base_of_image;
-                                offsets
-                                    .entry(unloaded.name.clone())
-                                    .or_insert_with(BTreeSet::new)
-                                    .insert(offset);
+                CallStack {
+                    frames,
+                    info,
+                    thread_id: id,
+                    thread_name: name,
+                    last_error_value: thread.last_error(self.system_info.cpu, &self.memory_list),
+                }
+            })
+            .collect();
+
+        // Collect up info on unimplemented/unknown modules
+        let unknown_streams = dump.unknown_streams().collect();
+        let unimplemented_streams = dump.unimplemented_streams().collect();
+
+        // Get symbol stats from the symbolizer
+        let symbol_stats = symbol_provider.stats();
+
+        // Process create time is optional.
+        let (process_id, process_create_time) = if let Some(misc_info) = self.misc_info.as_ref() {
+            (
+                misc_info.raw.process_id().cloned(),
+                misc_info.process_create_time(),
+            )
+        } else {
+            (None, None)
+        };
+
+        let mut state = ProcessState {
+            process_id,
+            time: SystemTime::UNIX_EPOCH + Duration::from_secs(dump.header.time_date_stamp as u64),
+            process_create_time,
+            cert_info: self.evil.certs,
+            exception_info,
+            assertion: None,
+            requesting_thread,
+            system_info: self.system_info,
+            linux_standard_base: self.linux_standard_base,
+            mac_crash_info: self.mac_crash_info,
+            threads,
+            modules: self.modules,
+            unloaded_modules: self.unloaded_modules,
+            unknown_streams,
+            unimplemented_streams,
+            symbol_stats,
+        };
+
+        // Report the unwalked result
+        if let Some(reporter) = self.options.stat_reporter {
+            reporter.add_unwalked_result(&state);
+        }
+
+        {
+            let memory_list = &self.memory_list;
+            let modules = &state.modules;
+            let system_info = &state.system_info;
+            let unloaded_modules = &state.unloaded_modules;
+            let options = &self.options;
+
+            futures_util::future::join_all(
+                state
+                    .threads
+                    .iter_mut()
+                    .zip(self.thread_list.threads.iter())
+                    .enumerate()
+                    .map(|(i, (stack, thread))| async move {
+                        let mut stack_memory = thread.stack_memory(memory_list);
+                        // Always choose the memory region that is referenced by the context,
+                        // as the `exception_context` may refer to a different memory region than
+                        // the `thread_context`, which in turn would fail to stack walk.
+                        let stack_ptr = stack
+                            .frames
+                            .get(0)
+                            .map(|ctx_frame| ctx_frame.context.get_stack_pointer());
+                        if let Some(stack_ptr) = stack_ptr {
+                            let contains_stack_ptr = stack_memory
+                                .as_ref()
+                                .and_then(|memory| memory.get_memory_at_address::<u64>(stack_ptr))
+                                .is_some();
+                            if !contains_stack_ptr {
+                                stack_memory =
+                                    memory_list.memory_at_address(stack_ptr).or(stack_memory);
                             }
-
-                            frame.unloaded_modules = offsets;
                         }
-                    }
 
-                    if options.recover_function_args {
-                        arg_recovery::fill_arguments(stack, stack_memory);
-                    }
+                        stackwalker::walk_stack(
+                            i,
+                            options,
+                            stack,
+                            stack_memory,
+                            modules,
+                            system_info,
+                            symbol_provider,
+                        )
+                        .await;
 
-                    // Report the unwalked result
-                    if let Some(reporter) = options.stat_reporter {
-                        reporter.inc_processed_threads();
-                    }
+                        for frame in &mut stack.frames {
+                            // If the frame doesn't have a loaded module, try to find an unloaded module
+                            // that overlaps with its address range. The may be multiple, so record all
+                            // of them and the offsets this frame has in them.
+                            if frame.module.is_none() {
+                                let mut offsets = BTreeMap::new();
+                                for unloaded in
+                                    unloaded_modules.modules_at_address(frame.instruction)
+                                {
+                                    let offset = frame.instruction - unloaded.raw.base_of_image;
+                                    offsets
+                                        .entry(unloaded.name.clone())
+                                        .or_insert_with(BTreeSet::new)
+                                        .insert(offset);
+                                }
 
-                    stack
-                }),
-        )
-        .await
-    };
+                                frame.unloaded_modules = offsets;
+                            }
+                        }
 
-    let symbol_stats = symbol_provider.stats();
-    state.symbol_stats = symbol_stats;
+                        if options.recover_function_args {
+                            arg_recovery::fill_arguments(stack, stack_memory);
+                        }
 
-    Ok(state)
+                        // Report the unwalked result
+                        if let Some(reporter) = options.stat_reporter {
+                            reporter.inc_processed_threads();
+                        }
+
+                        stack
+                    }),
+            )
+            .await
+        };
+
+        let symbol_stats = symbol_provider.stats();
+        state.symbol_stats = symbol_stats;
+
+        Ok(state)
+    }
+}
+
+struct ExceptionDetails<'a> {
+    info: crate::ExceptionInfo,
+    context: Option<std::borrow::Cow<'a, MinidumpContext>>,
+    instruction_registers: BTreeSet<&'static str>,
 }
 
 /// If a non-canonical access caused a crash, return the real address

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -60,7 +60,7 @@ async fn test_processor() {
     // TODO:
     // assert_eq!(state.system_info.cpu_info.unwrap(),
     // "GenuineIntel family 6 model 13 stepping 8");
-    assert_eq!(state.exception_info.unwrap().address, 0x45);
+    assert_eq!(state.exception_info.unwrap().address.0, 0x45);
     assert_eq!(state.threads.len(), 2);
     assert_eq!(state.requesting_thread.unwrap(), 0);
 
@@ -295,13 +295,15 @@ async fn test_bit_flip() {
 
     let state = read_synth_dump(dump).await;
 
-    assert_eq!(
-        state
-            .exception_info
-            .expect("missing exception info")
-            .possible_bit_flips,
-        vec![0x80000]
-    );
+    let bit_flips = state
+        .exception_info
+        .expect("missing exception info")
+        .possible_bit_flips;
+
+    assert_eq!(bit_flips.len(), 1);
+    let bf = bit_flips.into_iter().next().unwrap();
+    assert_eq!(bf.address.0, 0x80000);
+    assert_eq!(bf.details, Default::default());
 }
 
 #[tokio::test]

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-brief.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-brief.snap
@@ -1,6 +1,5 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 308
 expression: stdout
 ---
 Operating system: Windows NT
@@ -10,7 +9,7 @@ CPU: x86
      1 CPU
 
 Crash reason:  EXCEPTION_ACCESS_VIOLATION_WRITE
-Crash address: 0x45
+Crash address: 0x00000045
 Process uptime: 0 seconds
 
 Thread 0  (crashed)

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-stable-all.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-stable-all.snap
@@ -1,6 +1,5 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 224
 expression: stdout
 ---
 Operating system: Windows NT
@@ -10,7 +9,7 @@ CPU: x86
      1 CPU
 
 Crash reason:  EXCEPTION_ACCESS_VIOLATION_WRITE
-Crash address: 0x45
+Crash address: 0x00000045
 Process uptime: 0 seconds
 
 Thread 0  (crashed)

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-symbols.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-symbols.snap
@@ -1,6 +1,5 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 266
 expression: stdout
 ---
 Operating system: Windows NT
@@ -10,7 +9,7 @@ CPU: x86
      1 CPU
 
 Crash reason:  EXCEPTION_ACCESS_VIOLATION_WRITE
-Crash address: 0x45
+Crash address: 0x00000045
 Process uptime: 0 seconds
 
 Thread 0  (crashed)

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-unstable-all.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human-unstable-all.snap
@@ -1,6 +1,5 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 245
 expression: stdout
 ---
 Operating system: Windows NT
@@ -10,7 +9,7 @@ CPU: x86
      1 CPU
 
 Crash reason:  EXCEPTION_ACCESS_VIOLATION_WRITE
-Crash address: 0x45
+Crash address: 0x00000045
 Process uptime: 0 seconds
 
 Thread 0  (crashed)

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__human.snap
@@ -1,6 +1,5 @@
 ---
 source: minidump-stackwalk/tests/test-minidump-stackwalk.rs
-assertion_line: 379
 expression: stdout
 ---
 Operating system: Windows NT
@@ -10,7 +9,7 @@ CPU: x86
      1 CPU
 
 Crash reason:  EXCEPTION_ACCESS_VIOLATION_WRITE
-Crash address: 0x45
+Crash address: 0x00000045
 Process uptime: 0 seconds
 
 Thread 0  (crashed)

--- a/minidump/src/context.rs
+++ b/minidump/src/context.rs
@@ -1302,6 +1302,25 @@ impl MinidumpContext {
         })
     }
 
+    /// Get the size (in bytes) of general-purpose registers.
+    pub fn register_size(&self) -> usize {
+        fn get<T: CpuContext>(_: &T) -> usize {
+            std::mem::size_of::<T::Register>()
+        }
+
+        match &self.raw {
+            MinidumpRawContext::X86(ctx) => get(ctx),
+            MinidumpRawContext::Ppc(ctx) => get(ctx),
+            MinidumpRawContext::Ppc64(ctx) => get(ctx),
+            MinidumpRawContext::Amd64(ctx) => get(ctx),
+            MinidumpRawContext::Sparc(ctx) => get(ctx),
+            MinidumpRawContext::Arm(ctx) => get(ctx),
+            MinidumpRawContext::Arm64(ctx) => get(ctx),
+            MinidumpRawContext::OldArm64(ctx) => get(ctx),
+            MinidumpRawContext::Mips(ctx) => get(ctx),
+        }
+    }
+
     /// Write a human-readable description of this `MinidumpContext` to `f`.
     ///
     /// This is very verbose, it is the format used by `minidump_dump`.

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -4486,7 +4486,7 @@ impl<'a> MinidumpException<'a> {
         &self,
         system_info: &MinidumpSystemInfo,
         misc: Option<&MinidumpMiscInfo>,
-    ) -> Option<Cow<MinidumpContext>> {
+    ) -> Option<Cow<'a, MinidumpContext>> {
         MinidumpContext::read(self.context?, self.endian, system_info, misc)
             .ok()
             .map(Cow::Owned)


### PR DESCRIPTION
values.

This includes (somewhat arbitrary) confidence values to help in determining the confidence of a bit flip.

Closes #808.

Starting as a draft because documentation needs to be updated.