### PR TITLE
Skip modules with bad image sizes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 # Next Version
 
 * Make all `minidump-common::format` structs writable with `scroll`.
+* Don't fail reading the entire module list if one module has an invalid size.
 
 # Version 0.15.2 (2022-12-07)
 

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -1509,6 +1509,7 @@ impl<'a> MinidumpStream<'a> for MinidumpModuleList {
                 // Bad image size.
                 tracing::warn!(
                     module_index,
+                    base = raw.base_of_image,
                     size = raw.size_of_image,
                     "bad module image size"
                 );


### PR DESCRIPTION
When encountering a module with a bad image size, log a warning and continue instead of returning an error for the whole module list.