### PR TITLE
Replace `encoding` with `encoding_rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,70 +508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
-dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
-]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,7 +1066,7 @@ dependencies = [
  "arbitrary",
  "debugid",
  "doc-comment",
- "encoding",
+ "encoding_rs",
  "memmap2",
  "minidump-common",
  "minidump-synth",
@@ -1202,7 +1138,6 @@ dependencies = [
 name = "minidump-synth"
 version = "0.15.2"
 dependencies = [
- "encoding",
  "minidump-common",
  "scroll",
  "test-assembler",

--- a/minidump-synth/Cargo.toml
+++ b/minidump-synth/Cargo.toml
@@ -13,5 +13,4 @@ edition = "2021"
 [dependencies]
 test-assembler = "0.1.5"
 minidump-common = { version = "0.15.2", path = "../minidump-common" }
-encoding = "0.2"
 scroll = "0.11.0"

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 debugid = "0.8.0"
-encoding = "0.2"
+encoding_rs = "0.8"
 tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.5.7"
 minidump-common = { version = "0.15.2", path = "../minidump-common" }


### PR DESCRIPTION
`encoding` is [unmaintained](https://rustsec.org/advisories/RUSTSEC-2021-0153.html), this PR just replaces its usage in `minidump` with `encoding_rs` and completely gets rid of it in `minidump-synth` in favor of just using `std::str::encode_utf16`