### PR TITLE
Start to fix DebugInfoSymbolProvider

### DIFF
--- a/minidump-unwind/src/symbols.rs
+++ b/minidump-unwind/src/symbols.rs
@@ -438,7 +438,7 @@ pub mod debuginfo {
         pub fn function_by_address(&self, addr: u64) -> Option<&Function> {
             // Get the index of the first function that starts after our search address.
             let functions = &self.functions;
-            let index_after_location = functions.partition_point(|f| addr < f.address);
+            let index_after_location = functions.partition_point(|f| addr >= f.address);
             if index_after_location == 0 {
                 return None;
             }
@@ -536,7 +536,8 @@ pub mod debuginfo {
 
             // From this point on, we consider that symbols were found for the module, so we no
             // longer return FillSymbolError.
-            let function = info.function_by_address(frame.get_instruction());
+            let function =
+                info.function_by_address(frame.get_instruction() - module.base_address());
 
             if let Some(function) = function {
                 // XXX parameter size


### PR DESCRIPTION
This PR fixes two bugs that prevented DebugInfoSymbolProvider from ever resolving an address to a function:

1. `partition_point` expects a closure that returns true at the head of the slice and false at the tail, but the closure originally provided did the opposite. This meant that `partition_point` always returned `0`, and `function_by_address` would therefore always return `None`.
2. `fill_symbol` was passing the raw instruction address into `function_by_address` rather than the debiased address required to resolve properly against the function addresses embedded in the binary.

As an example, here's before and after output of running minidump-stackwalk with `--use-local-debuginfo` on a minidump produced by the `diskwrite` example in the crash-handling repo: https://gist.github.com/sfackler/578de5039b6734ba4b7ce8044ca5a2d0

The function resolution process still seems a bit broken, but this gets it closer.