### PR TITLE
Bug 1663983 - Check for memory accesses to likely guard pages.

### DIFF
--- a/minidump-processor/json-schema.md
+++ b/minidump-processor/json-schema.md
@@ -140,7 +140,10 @@ anyway.
     "memory_accesses": [
       {
         "address": <hexstring>,
-        "size": <u32>
+        "size": <u32>,
+        /// Whether the address falls in a likely guard page (typically indicating buffer overflow).
+        /// This field may only be present when the value is `true`.
+        "is_likely_guard_page": <bool>
       }
     ],
 

--- a/minidump-processor/src/op_analysis.rs
+++ b/minidump-processor/src/op_analysis.rs
@@ -65,6 +65,8 @@ pub struct MemoryAccess {
     pub address: u64,
     /// Whether or not this memory access is likely the result of a null-pointer dereference
     pub is_likely_null_pointer_dereference: bool,
+    /// Whether or not this memory access was part of a likely guard page.
+    pub is_likely_guard_page: bool,
     /// The size of the memory access
     ///
     /// Note that this is optional, as there are weird instructions that do not know the size
@@ -302,11 +304,13 @@ mod amd64 {
                     Operand::DisplacementU32(disp) => Some(MemoryAccess {
                         address: disp.into(),
                         is_likely_null_pointer_dereference: false,
+                        is_likely_guard_page: false,
                         size: mem_size,
                     }),
                     Operand::DisplacementU64(disp) => Some(MemoryAccess {
                         address: disp,
                         is_likely_null_pointer_dereference: false,
+                        is_likely_guard_page: false,
                         size: mem_size,
                     }),
                     other_operand => {
@@ -336,6 +340,7 @@ mod amd64 {
                 accesses.push(MemoryAccess {
                     address,
                     is_likely_null_pointer_dereference: address == 0,
+                    is_likely_guard_page: false,
                     size: Some(1),
                 });
             };
@@ -394,6 +399,7 @@ mod amd64 {
             let mut access = MemoryAccess {
                 address: 0,
                 is_likely_null_pointer_dereference: false,
+                is_likely_guard_page: false,
                 size: access_size,
             };
 

--- a/minidump-processor/src/process_state.rs
+++ b/minidump-processor/src/process_state.rs
@@ -457,6 +457,9 @@ impl ProcessState {
                         } else {
                             writeln!(f, "     Size: Unknown")?;
                         }
+                        if access.is_likely_guard_page {
+                            writeln!(f, "     This address falls in a likely guard page.")?;
+                        }
                     }
                 } else {
                     writeln!(f, "No memory accessed by instruction")?;
@@ -706,10 +709,15 @@ Unknown streams encountered:
                 "memory_accesses": self.exception_info.as_ref().and_then(|info| {
                     info.memory_accesses.as_ref().map(|accesses| {
                         accesses.iter().map(|access| {
-                            json!({
+                            let mut map = json!({
                                 "address": json_hex(access.address),
                                 "size": access.size,
-                            })
+                            });
+                            // Only add the `is_likely_guard_page` field when it is affirmative.
+                            if access.is_likely_guard_page {
+                                map["is_likely_guard_page"] = true.into();
+                            }
+                            map
                         }).collect::<Vec<_>>()
                     })
                 }),

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -5,6 +5,7 @@ use minidump::system_info::{Cpu, Os};
 use minidump::{
     Error, Minidump, MinidumpContext, MinidumpContextValidity, MinidumpRawContext, Module,
 };
+use minidump_common::format::MemoryProtection;
 use minidump_processor::{LinuxStandardBase, ProcessState};
 use minidump_unwind::{simple_symbol_supplier, CallStackInfo, FrameTrust, Symbolizer};
 use std::path::{Path, PathBuf};
@@ -334,4 +335,78 @@ async fn test_no_bit_flip_32bit() {
         .expect("missing exception info")
         .possible_bit_flips
         .is_empty());
+}
+
+#[tokio::test]
+async fn test_guard_pages() {
+    let context = minidump_synth::amd64_context(Endian::Little, 0x2000, 0x81000);
+
+    // The bytes here are the opcode `mov al, [rsp]`. We use rsp only because it's convenient to
+    // set using the `amd64_context` function.
+    let memory = Memory::with_section(
+        Section::with_endian(Endian::Little).append_bytes(&[0x8a, 0x04, 0x24]),
+        0x2000,
+    );
+    let stack = Memory::with_section(Section::with_endian(Endian::Little), 0x1000);
+    let heap_info = MemoryInfo::new(
+        Endian::Little,
+        0x80000,
+        0x80000,
+        0,
+        4096,
+        0,
+        MemoryProtection::PAGE_EXECUTE_READWRITE.bits(),
+        0,
+    );
+    let guard_page_info = MemoryInfo::new(
+        Endian::Little,
+        0x81000,
+        0x81000,
+        0,
+        4096,
+        0,
+        MemoryProtection::PAGE_NOACCESS.bits(),
+        0,
+    );
+
+    let thread = Thread::new(Endian::Little, 1, &stack, &context);
+    let system_info = SystemInfo::new(Endian::Little).set_processor_architecture(
+        minidump_common::format::ProcessorArchitecture::PROCESSOR_ARCHITECTURE_AMD64 as u16,
+    );
+
+    let context_label = context.file_offset();
+    let context_size = context.file_size();
+
+    let dump = SynthMinidump::with_endian(Endian::Little).add(context);
+
+    let mut ex = Exception::new(Endian::Little);
+    ex.thread_id = 1;
+    ex.exception_record.exception_address = 0x81000;
+    // Point the exception context at the main exception context.
+    // This is (size, offset).
+    ex.thread_context = (
+        context_size.value().unwrap() as u32,
+        context_label.value().unwrap() as u32,
+    );
+
+    let dump = dump
+        .add_thread(thread)
+        .add_exception(ex)
+        .add_system_info(system_info)
+        .add_memory(memory)
+        .add_memory(stack)
+        .add_memory_info(heap_info)
+        .add_memory_info(guard_page_info);
+
+    let state = read_synth_dump(dump).await;
+
+    let accesses = state
+        .exception_info
+        .expect("missing exception info")
+        .memory_accesses
+        .expect("no memory accesses");
+
+    assert_eq!(accesses.len(), 1);
+    assert_eq!(accesses[0].address, 0x81000);
+    assert!(accesses[0].is_likely_guard_page);
 }


### PR DESCRIPTION
This is useful for classifying exceptions (e.g., as buffer overflows).