### PR TITLE
Switch to num-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,17 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,7 +1161,7 @@ dependencies = [
  "arbitrary",
  "bitflags",
  "debugid",
- "enum-primitive-derive",
+ "num-derive",
  "num-traits",
  "range-map",
  "scroll",
@@ -1356,6 +1345,17 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/breakpad-symbols/fuzz/Cargo.lock
+++ b/breakpad-symbols/fuzz/Cargo.lock
@@ -89,17 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn 1.0.95",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,7 +157,7 @@ version = "0.17.0"
 dependencies = [
  "bitflags",
  "debugid",
- "enum-primitive-derive",
+ "num-derive",
  "num-traits",
  "range-map",
  "scroll",
@@ -189,6 +178,17 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.95",
 ]
 
 [[package]]

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "rust-minidump/rust-minidump" }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 bitflags = "1.3.2"
 debugid = "0.8.0"
-enum-primitive-derive = "0.2.2"
+num-derive = "0.3"
 num-traits = "0.2"
 range-map = "0.2"
 scroll = { version = "0.11.0", features = ["derive"] }

--- a/minidump-common/src/errors/linux.rs
+++ b/minidump-common/src/errors/linux.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use enum_primitive_derive::Primitive;
+use num_derive::FromPrimitive;
 
 /// Values for
 /// [`MINIDUMP_EXCEPTION::exception_code`](crate::format::MINIDUMP_EXCEPTION::exception_code)
@@ -9,7 +9,7 @@ use enum_primitive_derive::Primitive;
 ///
 /// These are primarily signal numbers from bits/signum.h.
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinux {
     /// Hangup (POSIX)
     SIGHUP = 0x1u32,
@@ -78,7 +78,7 @@ pub enum ExceptionCodeLinux {
 }
 
 // These values come from asm-generic/siginfo.h
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 #[repr(i32)]
 pub enum ExceptionCodeLinuxSicode {
     SI_USER = 0,
@@ -93,7 +93,7 @@ pub enum ExceptionCodeLinuxSicode {
     SI_ASYNCNL = -60i32,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinuxSigillKind {
     ILL_ILLOPC = 1,
     ILL_ILLOPN = 2,
@@ -106,7 +106,7 @@ pub enum ExceptionCodeLinuxSigillKind {
     ILL_BADIADDR = 9,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinuxSigtrapKind {
     TRAP_BRKPT = 1,
     TRAP_TRACE = 2,
@@ -116,7 +116,7 @@ pub enum ExceptionCodeLinuxSigtrapKind {
     TRAP_PERF = 6,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinuxSigfpeKind {
     FPE_INTDIV = 1,
     FPE_INTOVF = 2,
@@ -128,7 +128,7 @@ pub enum ExceptionCodeLinuxSigfpeKind {
     FPE_FLTSUB = 8,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinuxSigsegvKind {
     SEGV_MAPERR = 1,
     SEGV_ACCERR = 2,
@@ -136,7 +136,7 @@ pub enum ExceptionCodeLinuxSigsegvKind {
     SEGV_PKUERR = 4,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinuxSigbusKind {
     BUS_ADRALN = 1,
     BUS_ADRERR = 2,
@@ -145,7 +145,7 @@ pub enum ExceptionCodeLinuxSigbusKind {
     BUS_MCEERR_AO = 5,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeLinuxSigsysKind {
     SYS_SECCOMP = 1,
     SYS_USER_DISPATCH = 2,

--- a/minidump-common/src/errors/macos.rs
+++ b/minidump-common/src/errors/macos.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use enum_primitive_derive::Primitive;
+use num_derive::FromPrimitive;
 
 /// Values for
 /// [`MINIDUMP_EXCEPTION::exception_code`](crate::format::MINIDUMP_EXCEPTION::exception_code)
@@ -12,7 +12,7 @@ use enum_primitive_derive::Primitive;
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/exception_types.h#L64-L105
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMac {
     /// code can be a kern_return_t
     EXC_BAD_ACCESS = 1,
@@ -39,7 +39,7 @@ pub enum ExceptionCodeMac {
 /// These are the relevant kern_return_t values from [osfmk/mach/kern_return.h][header]
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/kern_return.h#L70-L340
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadAccessKernType {
     KERN_INVALID_ADDRESS = 1,
     KERN_PROTECTION_FAILURE = 2,
@@ -55,7 +55,7 @@ pub enum ExceptionCodeMacBadAccessKernType {
 /// See the [osfmk/mach/arm/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/arm/exception.h#L66-L75
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadAccessArmType {
     EXC_ARM_DA_ALIGN = 0x0101,
     EXC_ARM_DA_DEBUG = 0x0102,
@@ -69,7 +69,7 @@ pub enum ExceptionCodeMacBadAccessArmType {
 /// See the [osfmk/mach/ppc/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/b472f0612b8556cd1c6eb1c285ec1953de759e35/osfmk/mach/ppc/exception.h#L71-L78
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadAccessPpcType {
     EXC_PPC_VM_PROT_READ = 0x0101,
     EXC_PPC_BADSPACE = 0x0102,
@@ -81,7 +81,7 @@ pub enum ExceptionCodeMacBadAccessPpcType {
 /// See the [osfmk/mach/i386/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/i386/exception.h#L122
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadAccessX86Type {
     EXC_I386_GPFLT = 13,
 }
@@ -91,7 +91,7 @@ pub enum ExceptionCodeMacBadAccessX86Type {
 /// See the [osfmk/mach/arm/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/arm/exception.h#L48-L52
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadInstructionArmType {
     EXC_ARM_UNDEFINED = 1,
 }
@@ -101,7 +101,7 @@ pub enum ExceptionCodeMacBadInstructionArmType {
 /// See the [osfmk/mach/ppc/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/b472f0612b8556cd1c6eb1c285ec1953de759e35/osfmk/mach/ppc/exception.h#L60-L69
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadInstructionPpcType {
     EXC_PPC_INVALID_SYSCALL = 1,
     EXC_PPC_UNIPL_INST = 2,
@@ -116,7 +116,7 @@ pub enum ExceptionCodeMacBadInstructionPpcType {
 /// See the [osfmk/mach/i386/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/i386/exception.h#L74-L78
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBadInstructionX86Type {
     /// Invalid Operation
     EXC_I386_INVOP = 1,
@@ -155,7 +155,7 @@ pub enum ExceptionCodeMacBadInstructionX86Type {
 /// See the [osfmk/mach/arm/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/arm/exception.h#L54-L64
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacArithmeticArmType {
     EXC_ARM_FP_IO = 1,
     EXC_ARM_FP_DZ = 2,
@@ -170,7 +170,7 @@ pub enum ExceptionCodeMacArithmeticArmType {
 /// See the [osfmk/mach/ppc/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/b472f0612b8556cd1c6eb1c285ec1953de759e35/osfmk/mach/ppc/exception.h#L80-L90
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacArithmeticPpcType {
     /// Integer ovrflow
     EXC_PPC_OVERFLOW = 1,
@@ -198,7 +198,7 @@ pub enum ExceptionCodeMacArithmeticPpcType {
 /// See the [osfmk/mach/i386/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/i386/exception.h#L80-L91
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacArithmeticX86Type {
     EXC_I386_DIV = 1,
     EXC_I386_INTO = 2,
@@ -218,7 +218,7 @@ pub enum ExceptionCodeMacArithmeticX86Type {
 /// [header1]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/ux_exception.h#L48-L52
 /// [header2]: https://github.com/apple/darwin-xnu/blob/b472f0612b8556cd1c6eb1c285ec1953de759e35/osfmk/mach/ppc/exception.h#L100-L105
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacSoftwareType {
     SIGABRT = 0x00010002u32,
     UNCAUGHT_NS_EXCEPTION = 0xDEADC0DE,
@@ -234,7 +234,7 @@ pub enum ExceptionCodeMacSoftwareType {
 /// See the [osfmk/mach/arm/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/arm/exception.h#L77-L81
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBreakpointArmType {
     EXC_ARM_BREAKPOINT = 1,
 }
@@ -244,7 +244,7 @@ pub enum ExceptionCodeMacBreakpointArmType {
 /// See the [osfmk/mach/ppc/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/b472f0612b8556cd1c6eb1c285ec1953de759e35/osfmk/mach/ppc/exception.h#L108-L112
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBreakpointPpcType {
     EXC_PPC_BREAKPOINT = 1,
 }
@@ -254,7 +254,7 @@ pub enum ExceptionCodeMacBreakpointPpcType {
 /// See the [osfmk/mach/i386/exception.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/mach/i386/exception.h#L102-L107
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacBreakpointX86Type {
     EXC_I386_SGL = 1,
     EXC_I386_BPT = 2,
@@ -265,7 +265,7 @@ pub enum ExceptionCodeMacBreakpointX86Type {
 /// See the [osfmk/kern/exc_resource.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/exc_resource.h#L60-L65
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacResourceType {
     RESOURCE_TYPE_CPU = 1,
     RESOURCE_TYPE_WAKEUPS = 2,
@@ -279,7 +279,7 @@ pub enum ExceptionCodeMacResourceType {
 /// See the [osfmk/kern/exc_resource.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/exc_resource.h#L67-L69
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacResourceCpuFlavor {
     FLAVOR_CPU_MONITOR = 1,
     FLAVOR_CPU_MONITOR_FATAL = 2,
@@ -290,7 +290,7 @@ pub enum ExceptionCodeMacResourceCpuFlavor {
 /// See the [osfmk/kern/exc_resource.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/exc_resource.h#L67-L69
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacResourceWakeupsFlavor {
     FLAVOR_WAKEUPS_MONITOR = 1,
 }
@@ -300,7 +300,7 @@ pub enum ExceptionCodeMacResourceWakeupsFlavor {
 /// See the [osfmk/kern/exc_resource.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/exc_resource.h#L102-L103
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacResourceMemoryFlavor {
     FLAVOR_HIGH_WATERMARK = 1,
 }
@@ -310,7 +310,7 @@ pub enum ExceptionCodeMacResourceMemoryFlavor {
 /// See the [osfmk/kern/exc_resource.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/exc_resource.h#L164-L166
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacResourceIOFlavor {
     FLAVOR_IO_PHYSICAL_WRITES = 1,
     FLAVOR_IO_LOGICAL_WRITES = 2,
@@ -321,7 +321,7 @@ pub enum ExceptionCodeMacResourceIOFlavor {
 /// See the [osfmk/kern/exc_resource.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/osfmk/kern/exc_resource.h#L136-L137
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacResourceThreadsFlavor {
     FLAVOR_THREADS_HIGH_WATERMARK = 1,
 }
@@ -331,7 +331,7 @@ pub enum ExceptionCodeMacResourceThreadsFlavor {
 /// See the [osfmk/kern/exc_guard.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/main/osfmk/kern/exc_guard.h
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacGuardType {
     GUARD_TYPE_NONE = 0,
     GUARD_TYPE_MACH_PORT = 1,
@@ -346,7 +346,7 @@ pub enum ExceptionCodeMacGuardType {
 /// See the [osfmk/mach/port.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/port.h
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacGuardMachPortFlavor {
     GUARD_EXC_DESTROY = 0x00000001,
     GUARD_EXC_MOD_REFS = 0x00000002,
@@ -378,7 +378,7 @@ pub enum ExceptionCodeMacGuardMachPortFlavor {
 /// See the [bsd/sys/guarded.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/main/bsd/sys/guarded.h
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacGuardFDFlavor {
     GUARD_EXC_CLOSE = 0x00000001,
     GUARD_EXC_DUP = 0x00000002,
@@ -394,7 +394,7 @@ pub enum ExceptionCodeMacGuardFDFlavor {
 /// See the [bsd/sys/guarded.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/main/bsd/sys/guarded.h
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacGuardVNFlavor {
     GUARD_EXC_RENAME_TO = 0x00000001,
     GUARD_EXC_RENAME_FROM = 0x00000002,
@@ -410,7 +410,7 @@ pub enum ExceptionCodeMacGuardVNFlavor {
 /// See the [osfmk/mach/vm_statistics.h][header] header in Apple's kernel sources
 ///
 /// [header]: https://github.com/apple/darwin-xnu/blob/main/osfmk/mach/vm_statistics.h
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeMacGuardVirtMemoryFlavor {
     GUARD_EXC_DEALLOC_GAP = 0x00000001,
 }

--- a/minidump-common/src/errors/windows.rs
+++ b/minidump-common/src/errors/windows.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-use enum_primitive_derive::Primitive;
+use num_derive::FromPrimitive;
 
 /// Values for
 /// [`MINIDUMP_EXCEPTION::exception_code`](crate::format::MINIDUMP_EXCEPTION::exception_code)
@@ -9,7 +9,7 @@ use enum_primitive_derive::Primitive;
 ///
 /// These values come from WinBase.h and WinNT.h with a few additions.
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeWindows {
     EXCEPTION_GUARD_PAGE = 0x80000001u32,
     EXCEPTION_DATATYPE_MISALIGNMENT = 0x80000002,
@@ -55,7 +55,7 @@ pub enum ExceptionCodeWindows {
 /// ```
 /// For the time being we only retain the ones we actually encounter in the wide.
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum WinErrorFacilityWindows {
     FACILITY_VISUALCPP = 109,
 }
@@ -72,7 +72,7 @@ pub enum WinErrorFacilityWindows {
 ///   | sed -r 's@([0-9]+) ([A-Z_0-9]+)@    \2 = \L\1,@'
 /// ```
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum WinErrorWindows {
     ERROR_SUCCESS = 0,
     ERROR_INVALID_FUNCTION = 1,
@@ -2914,7 +2914,7 @@ pub enum WinErrorWindows {
 ///   | sed -r 's@(0x[048C][0-9A-F]+) ([A-Z_0-9]+)@    \2 = \L\1,@'
 /// ```
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum NtStatusWindows {
     STATUS_SUCCESS = 0x00000000u32,
     STATUS_WAIT_1 = 0x00000001,
@@ -5763,7 +5763,7 @@ pub enum NtStatusWindows {
 /// | sed -r 's@([0-9]+) ([A-Z_0-9]+)@    \2 = \1,@'
 /// ```
 #[repr(u64)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum FastFailCode {
     FAST_FAIL_LEGACY_GS_VIOLATION = 0,
     FAST_FAIL_VTGUARD_CHECK_FAILURE = 1,
@@ -5842,7 +5842,7 @@ pub enum FastFailCode {
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_record
 #[repr(u64)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeWindowsAccessType {
     READ = 0,
     WRITE = 1,
@@ -5856,7 +5856,7 @@ pub enum ExceptionCodeWindowsAccessType {
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_record
 #[repr(u64)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ExceptionCodeWindowsInPageErrorType {
     READ = 0,
     WRITE = 1,

--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -36,7 +36,7 @@
 use std::fmt;
 
 use bitflags::bitflags;
-use enum_primitive_derive::Primitive;
+use num_derive::FromPrimitive;
 use scroll::{Endian, Pread, Pwrite, SizeWith};
 use smart_default::SmartDefault;
 
@@ -152,7 +152,7 @@ pub struct MINIDUMP_DIRECTORY {
 ///
 /// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ne-minidumpapiset-minidump_stream_type
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum MINIDUMP_STREAM_TYPE {
     /// An unused stream directory entry
     UnusedStream = 0,
@@ -436,7 +436,7 @@ pub const VS_FFI_STRUCVERSION: u32 = 0x00010000;
 /// [sym]: http://web.archive.org/web/20070915060650/http://www.x86.org/ftp/manuals/tools/sym.pdf
 /// [win2k]: https://dl.acm.org/citation.cfm?id=375734
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum CvSignature {
     /// PDB 2.0 CodeView data: 'NB10': [`CV_INFO_PDB20`]
     Pdb20 = 0x3031424e,
@@ -1471,7 +1471,7 @@ pub struct MINIDUMP_SYSTEM_INFO {
 /// Many of these are taken from definitions in WinNT.h, but several of them are
 /// Breakpad extensions.
 #[repr(u16)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum ProcessorArchitecture {
     PROCESSOR_ARCHITECTURE_INTEL = 0,
     PROCESSOR_ARCHITECTURE_MIPS = 1,
@@ -1503,7 +1503,7 @@ pub enum ProcessorArchitecture {
 /// The Windows values here are taken from defines in WinNT.h, but the rest are Breakpad
 /// extensions.
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum PlatformId {
     /// Windows 3.1
     VER_PLATFORM_WIN32s = 1,
@@ -1955,7 +1955,7 @@ pub struct MINIDUMP_ASSERTION_INFO {
 ///
 /// [fmt]: https://chromium.googlesource.com/breakpad/breakpad/+/88d8114fda3e4a7292654bd6ac0c34d6c88a8121/src/google_breakpad/common/minidump_format.h#1011
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Primitive)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, FromPrimitive)]
 pub enum AssertionType {
     Unknown = 0,
     InvalidParameter = 1,

--- a/minidump-processor/fuzz/Cargo.lock
+++ b/minidump-processor/fuzz/Cargo.lock
@@ -138,17 +138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,7 +280,7 @@ dependencies = [
  "arbitrary",
  "bitflags",
  "debugid",
- "enum-primitive-derive",
+ "num-derive",
  "num-traits",
  "range-map",
  "scroll",
@@ -389,6 +378,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/minidump-unwind/fuzz/Cargo.lock
+++ b/minidump-unwind/fuzz/Cargo.lock
@@ -113,17 +113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +230,7 @@ dependencies = [
  "arbitrary",
  "bitflags",
  "debugid",
- "enum-primitive-derive",
+ "num-derive",
  "num-traits",
  "range-map",
  "scroll",
@@ -286,6 +275,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/minidump/fuzz/Cargo.lock
+++ b/minidump/fuzz/Cargo.lock
@@ -51,17 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn 1.0.95",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +114,7 @@ version = "0.17.0"
 dependencies = [
  "bitflags",
  "debugid",
- "enum-primitive-derive",
+ "num-derive",
  "num-traits",
  "range-map",
  "scroll",
@@ -138,6 +127,17 @@ version = "0.14.0"
 dependencies = [
  "libfuzzer-sys",
  "minidump",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.95",
 ]
 
 [[package]]


### PR DESCRIPTION
While the last release of num-derive is rather old, its repo has received recent updates, one of which is a bump to syn 2. It's also worth noting that num-derive is under the same umbrella org as num-traits, also used.