### PR TITLE
Expose FileLookup fields

### DIFF
--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -174,8 +174,8 @@ fn replace_or_add_extension(filename: &str, match_extension: &str, new_extension
 /// A lookup we would like to perform for some file (sym, exe, pdb, dll, ...)
 #[derive(Debug, Clone)]
 pub struct FileLookup {
-    cache_rel: String,
-    server_rel: String,
+    pub cache_rel: String,
+    pub server_rel: String,
 }
 
 /// Get a relative symbol path at which to locate symbols for `module`.


### PR DESCRIPTION
While writing my own fetcher for Symbol files, I wanted to make use of the `lookup` method. Sadly, although it returns `FileLookup` object, which is `pub`, the fields therein are not.

I think this is an oversight. All functions that use `FileLookup` also return the object, and all those functions are `pub`. Clearly these were meant to be used from outside this module, but as the fields are not marked as `pub`, they cannot.

I ended up copying all these functions inside my own crate; which works fine, but having this fixed in this create would be nice :)