### PR TITLE
add `resolver = "2"` to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 exclude = [
     "testdata/*",
 ]
+resolver = "2"
 
 [workspace.metadata.release]
 shared-version = true


### PR DESCRIPTION
Addresses the warning that shows up with rust 1.72.0:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```