### PR TITLE
Drop support the ThreadIdNameMapping annotation

### DIFF
--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -849,8 +849,7 @@ impl<'a> MinidumpInfo<'a> {
                 let name = self
                     .thread_names
                     .get_name(thread.raw.thread_id)
-                    .map(|cow| cow.into_owned())
-                    .or_else(|| self.evil.thread_names.get(&thread.raw.thread_id).cloned());
+                    .map(|cow| cow.into_owned());
 
                 let (info, frames) = if let Some(context) = context {
                     let ctx = context.clone();

--- a/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__json-pretty-evil-symbols.snap
+++ b/minidump-stackwalk/tests/snapshots/test_minidump_stackwalk__json-pretty-evil-symbols.snap
@@ -86,7 +86,7 @@ expression: stdout
       }
     ],
     "last_error_value": null,
-    "thread_name": "MyThreadName",
+    "thread_name": null,
     "threads_index": 0
   },
   "lsb_release": null,
@@ -351,7 +351,7 @@ expression: stdout
         }
       ],
       "last_error_value": null,
-      "thread_name": "MyThreadName"
+      "thread_name": null
     },
     {
       "frame_count": 0,

--- a/testdata/evil.json
+++ b/testdata/evil.json
@@ -1,5 +1,3 @@
 {
-    "ModuleSignatureInfo": "{ \"rust-minidump\": [\"test_app.exe\", \"whatever.dll\"] }",
-
-    "ThreadIdNameMapping": "3060:\"MyThreadName\", 1:\"MyUnusedThreadName\","
+    "ModuleSignatureInfo": "{ \"rust-minidump\": [\"test_app.exe\", \"whatever.dll\"] }"
 }


### PR DESCRIPTION
We've been writing thread names in all minidumps for a while, it's time to get rid of the old external annotation.

This closes issue #480.