### PR TITLE
Fix redirect url parsing (#882)

### DIFF
--- a/breakpad-symbols/src/http.rs
+++ b/breakpad-symbols/src/http.rs
@@ -218,19 +218,13 @@ async fn individual_lookup_debug_info_by_code_info(
             }
 
             // new_url looks like some/path/stuff/xul.pdb/somedebugid/xul.sym and we want the debug
-            // file and debug id portions which are the third from end and second from end
-            let mut parts: Vec<&str> = new_url.split('/').collect();
-            if parts.len() < 3 {
-                return None;
-            }
-            while parts.len() > 3 {
-                parts.remove(0);
-            }
-
-            let debug_file_part = parts[0];
-            let debug_file = String::from(debug_file_part);
-            let debug_identifier_part = parts[1];
+            // file and debug id portions which are at fixed indexes from the end
+            let mut parts = new_url.rsplit('/');
+            let debug_identifier_part = parts.nth(1)?;
             let debug_identifier = DebugId::from_str(debug_identifier_part).ok()?;
+            let debug_file_part = parts.next()?;
+            let debug_file = String::from(debug_file_part);
+
             debug!("Found debug info {} {}", debug_file, debug_identifier);
             return Some(DebugInfoResult {
                 debug_file,

--- a/breakpad-symbols/src/http.rs
+++ b/breakpad-symbols/src/http.rs
@@ -216,10 +216,20 @@ async fn individual_lookup_debug_info_by_code_info(
             if new_url.starts_with('/') {
                 new_url = new_url.strip_prefix('/').unwrap_or(new_url);
             }
-            let mut parts = new_url.split('/');
-            let debug_file_part = parts.next()?;
+
+            // new_url looks like some/path/stuff/xul.pdb/somedebugid/xul.sym and we want the debug
+            // file and debug id portions which are the third from end and second from end
+            let mut parts: Vec<&str> = new_url.split('/').collect();
+            if parts.len() < 3 {
+                return None;
+            }
+            while parts.len() > 3 {
+                parts.remove(0);
+            }
+
+            let debug_file_part = parts[0];
             let debug_file = String::from(debug_file_part);
-            let debug_identifier_part = parts.next()?;
+            let debug_identifier_part = parts[1];
             let debug_identifier = DebugId::from_str(debug_identifier_part).ok()?;
             debug!("Found debug info {} {}", debug_file, debug_identifier);
             return Some(DebugInfoResult {


### PR DESCRIPTION
When the symbol supplier does a codeinfo lookup and it's successful, the symbol supplier gets back an HTTP 302 with a url to redirect to in the Location header. The path of that url may have additional parts at the beginning that should be ignored--the debug file and debug id are the third and second from the end.

This fixes the path part parsing so
individual_lookup_debug_info_by_code_info picks up the debug file and debug id correctly.

This fixes the code so it works with any of these symbols-url variations:

* `https://symbols.mozilla.org`
* `https://symbols.mozilla.org/`
* `https://symbols.mozilla.org/try`
* `https://symbols.mozilla.org/try/`

Fixes #882 