### PR TITLE
Avoid requiring a dependency on memmap2 to use Minidump<'_, Mmap>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,6 @@ dependencies = [
  "debugid",
  "doc-comment",
  "futures-util",
- "memmap2 0.9.3",
  "minidump",
  "minidump-common",
  "minidump-synth",

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -31,7 +31,6 @@ async-trait = "0.1.52"
 breakpad-symbols = { version = "0.19.1", path = "../breakpad-symbols" }
 debugid = "0.8.0"
 futures-util = "0.3.25"
-memmap2 = "0.9"
 minidump = { version = "0.19.1", path = "../minidump" }
 minidump-common = { version = "0.19.1", path = "../minidump-common" }
 minidump-unwind = { version = "0.19.1", path = "../minidump-unwind" }

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -33,7 +33,7 @@ fn locate_testdata() -> PathBuf {
     panic!("Couldn't find testdata directory! Tried: {:?}", paths);
 }
 
-fn read_test_minidump() -> Result<MmapMinidump<'static>, Error> {
+fn read_test_minidump() -> Result<MmapMinidump, Error> {
     let path = locate_testdata().join("test.dmp");
     println!("minidump: {path:?}");
     Minidump::read_path(&path)

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -3,7 +3,8 @@
 
 use minidump::system_info::{Cpu, Os};
 use minidump::{
-    Error, Minidump, MinidumpContext, MinidumpContextValidity, MinidumpRawContext, Module,
+    Error, Minidump, MinidumpContext, MinidumpContextValidity, MinidumpRawContext, MmapMinidump,
+    Module,
 };
 use minidump_common::format::MemoryProtection;
 use minidump_processor::{Limit, LinuxStandardBase, ProcessState};
@@ -32,7 +33,7 @@ fn locate_testdata() -> PathBuf {
     panic!("Couldn't find testdata directory! Tried: {:?}", paths);
 }
 
-fn read_test_minidump() -> Result<Minidump<'static, memmap2::Mmap>, Error> {
+fn read_test_minidump() -> Result<MmapMinidump<'static>, Error> {
     let path = locate_testdata().join("test.dmp");
     println!("minidump: {path:?}");
     Minidump::read_path(&path)

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -5182,11 +5182,14 @@ impl MinidumpCrashpadInfo {
     }
 }
 
+/// An index into the contents of a memory-mapped minidump.
+pub type MmapMinidump<'a> = Minidump<'a, Mmap>;
+
 impl<'a> Minidump<'a, Mmap> {
     /// Read a `Minidump` from a `Path` to a file on disk.
     ///
     /// See [the type definition](Minidump.html) for an example.
-    pub fn read_path<P>(path: P) -> Result<Minidump<'a, Mmap>, Error>
+    pub fn read_path<P>(path: P) -> Result<MmapMinidump<'a>, Error>
     where
         P: AsRef<Path>,
     {

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -5183,13 +5183,13 @@ impl MinidumpCrashpadInfo {
 }
 
 /// An index into the contents of a memory-mapped minidump.
-pub type MmapMinidump<'a> = Minidump<'a, Mmap>;
+pub type MmapMinidump = Minidump<'static, Mmap>;
 
-impl<'a> Minidump<'a, Mmap> {
+impl MmapMinidump {
     /// Read a `Minidump` from a `Path` to a file on disk.
     ///
     /// See [the type definition](Minidump.html) for an example.
-    pub fn read_path<P>(path: P) -> Result<MmapMinidump<'a>, Error>
+    pub fn read_path<P>(path: P) -> Result<MmapMinidump, Error>
     where
         P: AsRef<Path>,
     {

--- a/minidump/tests/test_minidump.rs
+++ b/minidump/tests/test_minidump.rs
@@ -2,7 +2,6 @@
 // file at the top-level directory of this distribution.
 
 use debugid::{CodeId, DebugId};
-use memmap2::Mmap;
 use minidump::system_info::{Cpu, Os};
 use minidump::*;
 use minidump_common::format as md;
@@ -25,12 +24,12 @@ fn get_test_minidump_path(filename: &str) -> PathBuf {
     path
 }
 
-fn read_test_minidump<'a>() -> Result<Minidump<'a, Mmap>, Error> {
+fn read_test_minidump<'a>() -> Result<MmapMinidump<'a>, Error> {
     let path = get_test_minidump_path("test.dmp");
     Minidump::read_path(path)
 }
 
-fn read_linux_minidump<'a>() -> Result<Minidump<'a, Mmap>, Error> {
+fn read_linux_minidump<'a>() -> Result<MmapMinidump<'a>, Error> {
     let path = get_test_minidump_path("linux-mini.dmp");
     Minidump::read_path(path)
 }

--- a/minidump/tests/test_minidump.rs
+++ b/minidump/tests/test_minidump.rs
@@ -24,12 +24,12 @@ fn get_test_minidump_path(filename: &str) -> PathBuf {
     path
 }
 
-fn read_test_minidump<'a>() -> Result<MmapMinidump<'a>, Error> {
+fn read_test_minidump() -> Result<MmapMinidump, Error> {
     let path = get_test_minidump_path("test.dmp");
     Minidump::read_path(path)
 }
 
-fn read_linux_minidump<'a>() -> Result<MmapMinidump<'a>, Error> {
+fn read_linux_minidump() -> Result<MmapMinidump, Error> {
     let path = get_test_minidump_path("linux-mini.dmp");
     Minidump::read_path(path)
 }


### PR DESCRIPTION
The main problem is that the dependency on memmap2 then needs to be the exact same as the one the minidump crate has, which doesn't necessarily line up.

Another option would be to reexport Mmap.