### PR TITLE
fix: restore the idx field on thread spans

### DIFF
--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -960,6 +960,7 @@ impl<'a> MinidumpInfo<'a> {
                         }
 
                         walk_stack(
+                            i,
                             |frame_idx: usize, frame: &StackFrame| {
                                 if let Some(reporter) = options.stat_reporter {
                                     reporter.add_walked_frame(i, frame_idx, frame);

--- a/minidump-unwind/README.md
+++ b/minidump-unwind/README.md
@@ -24,7 +24,7 @@ use minidump_unwind::{CallStack, http_symbol_supplier, Symbolizer, SystemInfo, w
 async fn main() {
     // Read the minidump
     let dump = Minidump::read_path("../testdata/test.dmp").unwrap();
- 
+
     // Configure the symbolizer and processor
     let symbols_urls = vec![String::from("https://symbols.totallyrealwebsite.org")];
     let symbols_paths = vec![];
@@ -56,6 +56,7 @@ async fn main() {
     let mut stack = CallStack::with_context(exception_context.into_owned());
 
     walk_stack(
+        0,
         (),
         &mut stack,
         stack_memory,
@@ -71,7 +72,7 @@ async fn main() {
         },
         &provider,
     ).await;
- 
+
     for frame in stack.frames {
         println!("{:?}", frame);
     }

--- a/minidump-unwind/fuzz/fuzz_targets/unwind.rs
+++ b/minidump-unwind/fuzz/fuzz_targets/unwind.rs
@@ -58,6 +58,7 @@ impl TestFixture {
         let mut stack = CallStack::with_context(context);
 
         walk_stack(
+            0,
             (),
             &mut stack,
             Some(UnifiedMemory::Memory(&stack_memory)),

--- a/minidump-unwind/src/amd64_unittest.rs
+++ b/minidump-unwind/src/amd64_unittest.rs
@@ -56,6 +56,7 @@ impl TestFixture {
         let mut stack = CallStack::with_context(context);
 
         walk_stack(
+            0,
             (),
             &mut stack,
             Some(UnifiedMemory::Memory(stack_memory)),

--- a/minidump-unwind/src/arm64_unittest.rs
+++ b/minidump-unwind/src/arm64_unittest.rs
@@ -86,6 +86,7 @@ impl TestFixture {
         let mut stack = CallStack::with_context(context);
 
         walk_stack(
+            0,
             (),
             &mut stack,
             Some(UnifiedMemory::Memory(&stack_memory)),

--- a/minidump-unwind/src/arm_unittest.rs
+++ b/minidump-unwind/src/arm_unittest.rs
@@ -56,6 +56,7 @@ impl TestFixture {
         let mut stack = CallStack::with_context(context);
 
         walk_stack(
+            0,
             (),
             &mut stack,
             Some(UnifiedMemory::Memory(&stack_memory)),

--- a/minidump-unwind/src/lib.rs
+++ b/minidump-unwind/src/lib.rs
@@ -736,8 +736,9 @@ impl<'a, F: FnMut(usize, &StackFrame) + Send + 'a> From<F> for OnWalkedFrame<'a>
     }
 }
 
-#[tracing::instrument(name = "unwind_thread", level = "trace", skip_all, fields(tid = stack.thread_id, tname = stack.thread_name.as_deref().unwrap_or("")))]
+#[tracing::instrument(name = "unwind_thread", level = "trace", skip_all, fields(idx = _thread_idx, tid = stack.thread_id, tname = stack.thread_name.as_deref().unwrap_or("")))]
 pub async fn walk_stack<P>(
+    _thread_idx: usize,
     on_walked_frame: impl Into<OnWalkedFrame<'_>>,
     stack: &mut CallStack,
     stack_memory: Option<UnifiedMemory<'_, '_>>,

--- a/minidump-unwind/src/x86_unittest.rs
+++ b/minidump-unwind/src/x86_unittest.rs
@@ -55,6 +55,7 @@ impl TestFixture {
         let mut stack = CallStack::with_context(context);
 
         walk_stack(
+            0,
             (),
             &mut stack,
             Some(UnifiedMemory::Memory(&stack_memory)),


### PR DESCRIPTION
the 'idx' fields on unwind_thread and unwind_frame (and those span names) are rust-minidump-private API used by minidump-debugger to do log filtering.