### PR TITLE
Validate `stack_memory` once in `walk_stack`

### DIFF
--- a/minidump-unwind/src/lib.rs
+++ b/minidump-unwind/src/lib.rs
@@ -752,6 +752,13 @@ pub async fn walk_stack<P>(
         stack.thread_id,
         stack.thread_name.as_deref().unwrap_or(""),
     );
+
+    // All the unwinder code down below in `get_caller_frame` requires a valid `stack_memory`,
+    // where _valid_ means that we can actually read something from it. A call to `memory_range` will validate that,
+    // as it will reject empty stack memory or one with an overflowing `size`.
+    let stack_memory =
+        stack_memory.and_then(|stack_memory| stack_memory.memory_range().map(|_| stack_memory));
+
     // Begin with the context frame, and keep getting callers until there are no more.
     let mut has_new_frame = !stack.frames.is_empty();
     let mut on_walked_frame = on_walked_frame.into();


### PR DESCRIPTION
Doing a little bit of profiling, I found that `UnifiedMemory::get_memory_at_address` is quite hot. This lead me to a comment that I added previously about doing overflow checks on every single access. Instead of doing that on every access, rather do it once ahead of using it within `walk_stack`.