### PR TITLE
Remove `chrono`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,21 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,18 +237,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets 0.52.0",
-]
 
 [[package]]
 name = "circular"
@@ -756,29 +729,6 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1380,7 +1330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
  "bitflags 2.4.2",
- "chrono",
  "hex",
 ]
 
@@ -2357,15 +2306,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.0",
-]
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Rust CI](https://github.com/rust-minidump/rust-minidump/workflows/Rust%20CI/badge.svg?branch=master)
+![Rust CI](https://github.com/rust-minidump/rust-minidump/workflows/Rust%20CI/badge.svg?branch=main)
 
 # Overview
 
@@ -7,8 +7,6 @@ This project provides type definitions, parsing, and analysis for the [minidump]
 It's fairly heavily modeled after [Google Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) for historical reasons, but there is no fundamental interoperability requirement between the two beyond the fact that they fundamentally handle the same inputs.
 
 This project has no "main" crate. It is a collection of crates that are developed together. What crate you should use depends on how "low-level" in the minidump format you want to get. By default you'll probably want to use [minidump-processor](https://crates.io/crates/minidump-processor) (library) or [minidump-stackwalk](https://crates.io/crates/minidump-stackwalk) (application), which provide the richest analysis.
-
-
 
 # Examples
 
@@ -43,7 +41,6 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 ```
-
 
 Analyze a minidump with [minidump-processor](https://crates.io/crates/minidump-processor):
 
@@ -99,7 +96,6 @@ async fn main() -> Result<(), ()> {
 }
 ```
 
-
 Analyze a (Firefox) minidump with [minidump-stackwalk](https://crates.io/crates/minidump-stackwalk):
 
 ```text
@@ -143,20 +139,13 @@ Thread 0  (crashed)
  ...
 ```
 
-
-
-
 # Libraries
-
 
 ## [minidump-common](minidump-common) [![crates.io](https://img.shields.io/crates/v/minidump-common.svg)](https://crates.io/crates/minidump-common) [![](https://docs.rs/minidump-common/badge.svg)](https://docs.rs/minidump-common)
 
 Basically "minidump-sys" -- minidump types and traits that are shared among several crates.
 
 Most notably [format.rs](minidump-common/src/format.rs) is basically a giant native rust header for [minidumpapiset.h](https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/) (with extra useful things added in like error code enums and breakpad extensions).
-
-
-
 
 ## [minidump](minidump) [![crates.io](https://img.shields.io/crates/v/minidump.svg)](https://crates.io/crates/minidump) [![](https://docs.rs/minidump/badge.svg)](https://docs.rs/minidump)
 
@@ -167,9 +156,6 @@ value will from a stream will request its dependencies.
 
 If you want richer analysis of the minidump (such as stackwalking and symbolication), use minidump-processor.
 
-
-
-
 ## [minidump-processor](minidump-processor) [![crates.io](https://img.shields.io/crates/v/minidump-processor.svg)](https://crates.io/crates/minidump-processor) [![](https://docs.rs/minidump-processor/badge.svg)](https://docs.rs/minidump-processor)
 
 High-level minidump analysis.
@@ -179,10 +165,6 @@ Builds on top of the `minidump` crate to provide a complete digest of the inform
 The biggest feature of minidump-processor is that it does stackwalking (computes a backtrace for every thread). Its analysis can be enhanced by providing it with symbols (i.e. using `breakpad-symbols`), producing more precise backtraces and symbolication (function names, source lines, etc.).
 
 It also knows all of the "quirks" of minidumps, and can smooth over details that are impractical for the minidump crate to handle.
-
-
-
-
 
 ## [breakpad-symbols](breakpad-symbols) [![crates.io](https://img.shields.io/crates/v/breakpad-symbols.svg)](https://crates.io/crates/breakpad-symbols) [![](https://docs.rs/breakpad-symbols/badge.svg)](https://docs.rs/breakpad-symbols)
 
@@ -198,22 +180,13 @@ Provides an API for evaluating breakpad CFI (and WIN) expressions.
 
 This is primarily designed for use by minidump-processor.
 
-
-
-
-
 ## [minidump-synth](minidump-synth)
 
 Provides a simple interface for mocking minidumps for unit tests.
 
 This is basically an internal dev-dependency of rust-minidump that we're publishing only so that `cargo publish` doesn't complain about it. I guess you could use it but we don't recommend it?
 
-
-
-
-
 # Applications
-
 
 ## [minidump-stackwalk](minidump-stackwalk) [![crates.io](https://img.shields.io/crates/v/minidump-stackwalk.svg)](https://crates.io/crates/minidump-stackwalk) [![](https://docs.rs/minidump-stackwalk/badge.svg)](https://docs.rs/minidump-stackwalk)
 
@@ -224,19 +197,13 @@ Also includes the functionality of the old minidump_dump tool (see the --dump fl
 
 See the [README](minidump-stackwalk/README.md) for details.
 
-
-
-
-
 # License
 
 This software is provided under the MIT license. See [LICENSE](LICENSE).
 
-
 # Release Notes
 
 See [RELEASES.md](RELEASES.md) for release notes, commits, and details on the upcoming release.
-
 
 # Contributing
 

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.9"
 minidump-common = { version = "0.20.0", path = "../minidump-common" }
 num-traits = "0.2"
-procfs-core = "0.16"
+procfs-core = { version = "0.16", default-features = false }
 range-map = "0.2"
 scroll = "0.12.0"
 thiserror = "1.0.37"


### PR DESCRIPTION
`procfs-core` uses `chrono` as a default feature, this is unneeded, I only noticed it because `minidump-writer` already removed the dependency, but it was still present in the lockfile due to `minidump`.

Also fixes the CI badge that wasn't fixed when `master` was renamed to `main`.