### PR TITLE
Add fuzz projects to dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,75 @@ updates:
   - dependency-name: env_logger
     versions:
     - 0.8.2
+- package-ecosystem: cargo
+  directory: "/breakpad-symbols/fuzz"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: reqwest
+    versions:
+    - 0.11.0
+    - 0.11.1
+    - 0.11.2
+  - dependency-name: nom
+    versions:
+    - 6.1.0
+  - dependency-name: env_logger
+    versions:
+    - 0.8.2
+- package-ecosystem: cargo
+  directory: "/minidump/fuzz"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: reqwest
+    versions:
+    - 0.11.0
+    - 0.11.1
+    - 0.11.2
+  - dependency-name: nom
+    versions:
+    - 6.1.0
+  - dependency-name: env_logger
+    versions:
+    - 0.8.2
+- package-ecosystem: cargo
+  directory: "/minidump-processor/fuzz"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: reqwest
+    versions:
+    - 0.11.0
+    - 0.11.1
+    - 0.11.2
+  - dependency-name: nom
+    versions:
+    - 6.1.0
+  - dependency-name: env_logger
+    versions:
+    - 0.8.2
+- package-ecosystem: cargo
+  directory: "/minidump-unwind/fuzz"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: reqwest
+    versions:
+    - 0.11.0
+    - 0.11.1
+    - 0.11.2
+  - dependency-name: nom
+    versions:
+    - 6.1.0
+  - dependency-name: env_logger
+    versions:
+    - 0.8.2


### PR DESCRIPTION
The fuzz projects need to be updated alongside the main project, otherwise build-fuzz is more likely to fail from time to time.