### PR TITLE
Update framehop and change `object` to have minimal features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "fallible-iterator 0.3.0",
- "gimli",
+ "gimli 0.28.1",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.2",
  "rustc-demangle",
 ]
 
@@ -589,17 +589,19 @@ dependencies = [
 
 [[package]]
 name = "framehop"
-version = "0.9.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bb3ea0d42943711eafa7a6182b47a21d51247d2ecad6641ff61d9213d099ea"
+checksum = "a1940574e932d1ed75aab25420312c0019d8dd91c6125bd51420272cd072008e"
 dependencies = [
  "arrayvec",
+ "cfg-if",
  "fallible-iterator 0.3.0",
- "gimli",
+ "gimli 0.29.0",
  "macho-unwind-info",
- "object",
+ "object 0.35.0",
  "pe-unwind-info",
  "thiserror",
+ "thiserror-no-std",
 ]
 
 [[package]]
@@ -693,7 +695,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+dependencies = [
+ "fallible-iterator 0.3.0",
  "stable_deref_trait",
 ]
 
@@ -1140,7 +1151,7 @@ dependencies = [
  "memmap2",
  "minidump",
  "minidump-common",
- "object",
+ "object 0.35.0",
  "scroll 0.12.0",
  "test-assembler",
  "tokio",
@@ -1285,6 +1296,15 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "object"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1692,14 +1712,14 @@ dependencies = [
  "debugid",
  "elsa",
  "flate2",
- "gimli",
+ "gimli 0.28.1",
  "linux-perf-data",
  "lzma-rs",
  "macho-unwind-info",
  "memchr",
  "msvc-demangler",
  "nom",
- "object",
+ "object 0.32.2",
  "pdb-addr2line",
  "rangemap",
  "rustc-demangle",
@@ -2026,6 +2046,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]

--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -861,10 +861,10 @@ impl Symbolizer {
                 let mut stats = SymbolStats::default();
                 match &result {
                     Ok(res) => {
-                        stats.symbol_url = res.symbols.url.clone();
+                        stats.symbol_url.clone_from(&res.symbols.url);
                         stats.loaded_symbols = true;
                         stats.corrupt_symbols = false;
-                        stats.extra_debug_info = res.extra_debug_info.clone();
+                        stats.extra_debug_info.clone_from(&res.extra_debug_info);
                     }
                     Err(SymbolError::NotFound) => {
                         stats.loaded_symbols = false;

--- a/minidump-unwind/Cargo.toml
+++ b/minidump-unwind/Cargo.toml
@@ -26,12 +26,12 @@ http = ["breakpad-symbols/http"]
 async-trait = "0.1.52"
 breakpad-symbols = { version = "0.21.1", path = "../breakpad-symbols" }
 cachemap2 = { version = "0.3.0", optional = true }
-framehop = { version = "0.9", features = ["object"], optional = true }
+framehop = { version = "0.11.2", features = ["object"], optional = true }
 futures-util = { version = "0.3.25", optional = true }
 memmap2 = { version = "0.9", optional = true }
 minidump = { version = "0.21.1", path = "../minidump" }
 minidump-common = { version = "0.21.1", path = "../minidump-common" }
-object = { version = "0.32", optional = true }
+object = { version = "0.35", default-features = false, features = ["read"], optional = true }
 scroll = "0.12.0"
 tracing = { version = "0.1.34", features = ["log"] }
 wholesym = { version = "0.4", optional = true }


### PR DESCRIPTION
Consumers can add more features to change object reading if desired.

The way the crate is written, at least one of `coff`/`elf`/`macho`/`pe`/`wasm`/`xcoff` must be enabled for `object::read::File` to be available. While we could limit the features even further and make consumers choose which formats to support, this instead assumes that they want to be able to read any of the formats since we need to choose at least one anyway.