### PR TITLE
Limit non-canonical inconsistency detection to selected opcodes

### DIFF
--- a/minidump-processor/src/op_analysis.rs
+++ b/minidump-processor/src/op_analysis.rs
@@ -355,10 +355,7 @@ mod amd64 {
             let Some(opcode) = AccessDerivableOpcode::from_opcode(instruction.opcode()) else {
                 return false;
             };
-            !matches!(
-                opcode,
-                AccessDerivableOpcode::MOVAPS | AccessDerivableOpcode::UCOMISS
-            )
+            !matches!(opcode, AccessDerivableOpcode::MOVAPS)
         }
     }
 


### PR DESCRIPTION
Resolves  #1031

Also renamed a few functions/variables to better distinguish between general protection fault and non-canonical crash.