### PR TITLE
Add soft error stream for minidump-writer #31

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -323,6 +323,9 @@ pub enum MINIDUMP_STREAM_TYPE {
 
     /// The contents of /proc/self/limits from a Linux system
     MozLinuxLimits = 0x4d7a0003,
+
+    /// Soft errors reported during minidump generation
+    MozSoftErrors = 0x4d7a0004,
 }
 
 impl From<MINIDUMP_STREAM_TYPE> for u32 {


### PR DESCRIPTION
This is a pretty simple change to allow Minidump-Writer to have the new soft error stream.

See: https://github.com/rust-minidump/minidump-writer/issues/31