### PR TITLE
Use workspace settings for packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ exclude = [
 ]
 resolver = "2"
 
+[workspace.package]
+license = "MIT"
+homepage = "https://github.com/rust-minidump/rust-minidump"
+repository = "https://github.com/rust-minidump/rust-minidump"
+version = "0.24.1"
+
 [workspace.metadata.release]
 shared-version = true
 consolidate-commits = true

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "breakpad-symbols"
 description = "A library for working with Google Breakpad's text-format symbol files."
-version = "0.24.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 exclude = ["testdata/*"]
 edition = "2018"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [badges]
 travis-ci = { repository = "rust-minidump/rust-minidump" }

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "minidump-common"
 description = "Some common types for working with minidump files."
-version = "0.24.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 readme = "README.md"
-license = "MIT"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 edition = "2018"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [badges]
 travis-ci = { repository = "rust-minidump/rust-minidump" }

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "minidump-processor"
 description = "A library for producing stack traces and other useful information from minidump files."
-version = "0.24.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 edition = "2018"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [badges]
 travis-ci = { repository = "rust-minidump/rust-minidump" }

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "minidump-stackwalk"
 description = "Analyzes minidumps and produces a report (either human-readable or JSON)"
-version = "0.24.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
-license = "MIT"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 keywords = ["breakpad", "symbols"]
 categories = ["parsing"]
 readme = "README.md"
 edition = "2018"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [badges]
 travis-ci = { repository = "rust-minidump/rust-minidump" }

--- a/minidump-synth/Cargo.toml
+++ b/minidump-synth/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "minidump-synth"
 description = "A library for producing synthetic minidumps for testing."
-version = "0.24.1"
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 test-assembler = "0.1.5"

--- a/minidump-unwind/Cargo.toml
+++ b/minidump-unwind/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "minidump-unwind"
 description = "A library for producing stack traces from minidump files."
-version = "0.24.1"
 authors = ["Alex Franchuk <afranchuk@mozilla.com>"]
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 edition = "2018"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [badges]
 travis-ci = { repository = "rust-minidump/rust-minidump" }

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "minidump"
 description = "A parser for the minidump format."
-version = "0.24.1"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
-license = "MIT"
-homepage = "https://github.com/rust-minidump/rust-minidump"
-repository = "https://github.com/rust-minidump/rust-minidump"
 keywords = ["breakpad", "symbols", "minidump"]
 categories = ["parsing"]
 readme = "README.md"
 edition = "2018"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 arbitrary = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
Now that Cargo allows this, it seems better to just manage these settings in a single `Cargo.toml` file (especially the version!)