### PR TITLE
Extend the scan range when coming from a CFI frame

### DIFF
--- a/minidump-unwind/src/amd64.rs
+++ b/minidump-unwind/src/amd64.rs
@@ -249,11 +249,14 @@ where
 
     // Breakpad devs found that the first frame of an unwind can be really messed up,
     // and therefore benefits from a longer scan. Let's do it too.
-    let scan_range = if let FrameTrust::Context = args.callee_frame.trust {
-        extended_scan_range
-    } else {
-        default_scan_range
-    };
+    // Additionally, especially with JIT code, using an extended scan range when coming
+    // from a trusted source allows skipping over undetectable JIT frames.
+    let scan_range =
+        if let FrameTrust::Context | FrameTrust::CallFrameInfo = args.callee_frame.trust {
+            extended_scan_range
+        } else {
+            default_scan_range
+        };
 
     for i in 0..scan_range {
         let address_of_ip = last_sp.checked_add(i * POINTER_WIDTH)?;

--- a/minidump-unwind/src/arm.rs
+++ b/minidump-unwind/src/arm.rs
@@ -175,11 +175,14 @@ where
 
     // Breakpad devs found that the first frame of an unwind can be really messed up,
     // and therefore benefits from a longer scan. Let's do it too.
-    let scan_range = if let FrameTrust::Context = args.callee_frame.trust {
-        extended_scan_range
-    } else {
-        default_scan_range
-    };
+    // Additionally, especially with JIT code, using an extended scan range when coming
+    // from a trusted source allows skipping over undetectable JIT frames.
+    let scan_range =
+        if let FrameTrust::Context | FrameTrust::CallFrameInfo = args.callee_frame.trust {
+            extended_scan_range
+        } else {
+            default_scan_range
+        };
 
     for i in 0..scan_range {
         let address_of_pc = last_sp.checked_add(i * POINTER_WIDTH)?;

--- a/minidump-unwind/src/arm64.rs
+++ b/minidump-unwind/src/arm64.rs
@@ -307,11 +307,14 @@ where
 
     // Breakpad devs found that the first frame of an unwind can be really messed up,
     // and therefore benefits from a longer scan. Let's do it too.
-    let scan_range = if let FrameTrust::Context = args.callee_frame.trust {
-        extended_scan_range
-    } else {
-        default_scan_range
-    };
+    // Additionally, especially with JIT code, using an extended scan range when coming
+    // from a trusted source allows skipping over undetectable JIT frames.
+    let scan_range =
+        if let FrameTrust::Context | FrameTrust::CallFrameInfo = args.callee_frame.trust {
+            extended_scan_range
+        } else {
+            default_scan_range
+        };
 
     for i in 0..scan_range {
         let address_of_pc = last_sp.checked_add(i * POINTER_WIDTH)?;

--- a/minidump-unwind/src/arm64_old.rs
+++ b/minidump-unwind/src/arm64_old.rs
@@ -307,11 +307,14 @@ where
 
     // Breakpad devs found that the first frame of an unwind can be really messed up,
     // and therefore benefits from a longer scan. Let's do it too.
-    let scan_range = if let FrameTrust::Context = args.callee_frame.trust {
-        extended_scan_range
-    } else {
-        default_scan_range
-    };
+    // Additionally, especially with JIT code, using an extended scan range when coming
+    // from a trusted source allows skipping over undetectable JIT frames.
+    let scan_range =
+        if let FrameTrust::Context | FrameTrust::CallFrameInfo = args.callee_frame.trust {
+            extended_scan_range
+        } else {
+            default_scan_range
+        };
 
     for i in 0..scan_range {
         let address_of_pc = last_sp.checked_add(i * POINTER_WIDTH)?;

--- a/minidump-unwind/src/x86.rs
+++ b/minidump-unwind/src/x86.rs
@@ -201,11 +201,14 @@ where
 
     // Breakpad devs found that the first frame of an unwind can be really messed up,
     // and therefore benefits from a longer scan. Let's do it too.
-    let scan_range = if let FrameTrust::Context = args.callee_frame.trust {
-        extended_scan_range
-    } else {
-        default_scan_range
-    };
+    // Additionally, especially with JIT code, using an extended scan range when coming
+    // from a trusted source allows skipping over undetectable JIT frames.
+    let scan_range =
+        if let FrameTrust::Context | FrameTrust::CallFrameInfo = args.callee_frame.trust {
+            extended_scan_range
+        } else {
+            default_scan_range
+        };
 
     for i in 0..scan_range {
         let address_of_ip = last_sp.checked_add(i * POINTER_WIDTH)?;


### PR DESCRIPTION
I am currently exploring making JIT compiled frames unwind better. My main example I am working with is a Unity minidump which calls from native into (mono) JIT compiled code into more native code, where it eventually crashes.

Rough frames:

```
[Native: Bar] <- Crash
[Native: Foo]
[JIT: C]
[JIT: B]
[JIT: A]
[Native: `jit_invoke`]
```

All native frames have full unwind and debug symbols available, but I noticed that the stack scanner, did not extend far enough to find the native `jit_invoke` frame, it stopped in the middle of the JIT compiled code.

Expected Frames:

```
[Native: Bar]
[Native: Foo]
[0x00008123]
[Native: `jit_invoke`]
```

Actual Frames:

```
[Native: Bar]
[Native: Foo]
[0x00008123]
```

The idea is to default to the extended scan range, not only for pointers provided by the context, but also when we have a reasonably confidence that the provided values are valid.

Now this is would not be needed, if we extend the validity check to also be able to recognize JITed instructions. That requires another heuristic (e.g. proximity of the instruction addr to the previous instruction addr) or proper consideration of `MemoryInfoList` / `LinuxMaps` streams. With the real minidumps I have, these streams are *not* available (still looking into why crashpad doesn't seem to add the `MemoryInfoList` stream on Windows, for Linux there is straight up no support implemented).

In any case, extending the scan range seems to cover these cases.

---

I only added a test for `amd64` but made the change for all backends. Let me know if you want me to copy the same test multiple times or if I should only make the change in `amd64` (the platform which I actually currently work with).