### PR TITLE
Implement frame pointer scan for windows

### DIFF
--- a/minidump-unwind/src/amd64.rs
+++ b/minidump-unwind/src/amd64.rs
@@ -77,7 +77,7 @@ fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static st
     }
 }
 
-async fn get_caller_by_frame_pointer<P>(
+fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_AMD64,
     args: &GetCallerFrameArgs<'_, P>,
 ) -> Option<StackFrame>
@@ -188,9 +188,10 @@ where
         _ => resolve(0, 0)?,
     };
 
-    println!(
+    trace!(
         "frame pointer seems valid -- caller_ip: 0x{:016x}, caller_sp: 0x{:016x}",
-        caller_ip, caller_sp,
+        caller_ip,
+        caller_sp,
     );
 
     let caller_ctx = CONTEXT_AMD64 {
@@ -423,11 +424,9 @@ where
         frame = get_caller_by_cfi(ctx, args).await;
     }
     if frame.is_none() {
-        println!("START FP");
-        frame = get_caller_by_frame_pointer(ctx, args).await;
+        frame = get_caller_by_frame_pointer(ctx, args);
     }
     if frame.is_none() {
-        println!("START SCAN");
         frame = get_caller_by_scan(ctx, args).await;
     }
     let mut frame = frame?;

--- a/minidump-unwind/src/amd64.rs
+++ b/minidump-unwind/src/amd64.rs
@@ -77,7 +77,7 @@ fn callee_forwarded_regs(valid: &MinidumpContextValidity) -> HashSet<&'static st
     }
 }
 
-fn get_caller_by_frame_pointer<P>(
+async fn get_caller_by_frame_pointer<P>(
     ctx: &CONTEXT_AMD64,
     args: &GetCallerFrameArgs<'_, P>,
 ) -> Option<StackFrame>
@@ -85,17 +85,6 @@ where
     P: SymbolProvider + Sync,
 {
     let stack_memory = args.stack_memory;
-    // On Windows x64, frame-pointer unwinding purely with the data on the stack
-    // is not possible, as proper unwinding requires access to `UNWIND_INFO`,
-    // because the frame pointer does not necessarily point to the end of the
-    // frame.
-    // In particular, the docs state that:
-    // > [The frame register] offset permits pointing the FP register into the
-    // > middle of the local stack allocation [...]
-    // https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64
-    if args.system_info.os == Os::Windows {
-        return None;
-    }
 
     trace!("trying frame pointer");
     if let MinidumpContextValidity::Some(ref which) = args.valid() {
@@ -138,37 +127,70 @@ where
         // drowning the rest of the code in checked_add.
         return None;
     }
-    let caller_ip = stack_memory.get_memory_at_address(last_bp + POINTER_WIDTH)?;
-    let caller_bp = stack_memory.get_memory_at_address(last_bp)?;
-    let caller_sp = last_bp + POINTER_WIDTH * 2;
 
-    // If the recovered ip is not a canonical address it can't be
-    // the return address, so bp must not have been a frame pointer.
+    let resolve = |offset_max_scan, offset_step| -> Option<(u64, u64, u64)> {
+        for offset in 0..=offset_max_scan {
+            let offset = offset * offset_step;
+            let caller_ip = stack_memory.get_memory_at_address(last_bp + offset + POINTER_WIDTH)?;
+            let caller_bp = stack_memory.get_memory_at_address(last_bp + offset)?;
+            let caller_sp = last_bp + offset + POINTER_WIDTH * 2;
 
-    // Since we're assuming coherent frame pointers, check that the frame pointers
-    // and stack pointers are well-ordered.
-    if caller_sp <= last_bp || caller_bp < caller_sp {
-        trace!("rejecting frame pointer result for unreasonable frame pointer");
-        return None;
-    }
-    // Since we're assuming coherent frame pointers, check that the resulting
-    // frame pointer is still inside stack memory.
-    let _unused: Pointer = stack_memory.get_memory_at_address(caller_bp)?;
-    // Don't accept obviously wrong instruction pointers.
-    if is_non_canonical(caller_ip) {
-        trace!("rejecting frame pointer result for unreasonable instruction pointer");
-        return None;
-    }
-    // Don't accept obviously wrong stack pointers.
-    if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
-        trace!("rejecting frame pointer result for unreasonable stack pointer");
-        return None;
-    }
+            // If the recovered ip is not a canonical address it can't be
+            // the return address, so bp must not have been a frame pointer.
 
-    trace!(
+            // Since we're assuming coherent frame pointers, check that the frame pointers
+            // and stack pointers are well-ordered.
+            if caller_sp <= last_bp || caller_bp < caller_sp {
+                trace!("rejecting frame pointer result for unreasonable frame pointer");
+                continue;
+            }
+
+            // Since we're assuming coherent frame pointers, check that the resulting
+            // frame pointer is still inside stack memory.
+            let _unused: Pointer = stack_memory.get_memory_at_address(caller_bp)?;
+            // Don't accept obviously wrong instruction pointers.
+            if is_non_canonical(caller_ip) {
+                trace!("rejecting frame pointer result for unreasonable instruction pointer");
+                continue;
+            }
+            // Don't accept obviously wrong stack pointers.
+            if !stack_seems_valid(caller_sp, last_sp, stack_memory) {
+                trace!("rejecting frame pointer result for unreasonable stack pointer");
+                continue;
+            }
+
+            return Some((caller_ip, caller_bp, caller_sp));
+        }
+        None
+    };
+
+    let (caller_ip, caller_bp, caller_sp) = match args.system_info.os {
+        // On Windows x64, frame-pointer unwinding purely with the data on the stack
+        // is not possible, as proper unwinding requires access to `UNWIND_INFO`,
+        // because the frame pointer does not necessarily point to the end of the
+        // frame.
+        //
+        // In particular, the docs state that:
+        // > [The frame register] offset permits pointing the FP register into the
+        // > middle of the local stack allocation [...]
+        // https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64
+        //
+        // But we can combine traditional frame-pointer unwinding with a educated
+        // stack scan.
+        // We know the given frame pointer points to a maximum 240 bytes into the middle
+        // of the stack. We also know the offset steps in 16 byte increments.
+        // Using this information we can scan up the stack to find the caller instruction
+        // address as well as the adjacent caller frame pointer.
+        //
+        // If this educated scan ends up failing, there is still the fallback to traditional
+        // stack scanning to find the next frame.
+        Os::Windows => resolve(15, 2 * POINTER_WIDTH)?,
+        _ => resolve(0, 0)?,
+    };
+
+    println!(
         "frame pointer seems valid -- caller_ip: 0x{:016x}, caller_sp: 0x{:016x}",
-        caller_ip,
-        caller_sp,
+        caller_ip, caller_sp,
     );
 
     let caller_ctx = CONTEXT_AMD64 {
@@ -401,9 +423,11 @@ where
         frame = get_caller_by_cfi(ctx, args).await;
     }
     if frame.is_none() {
-        frame = get_caller_by_frame_pointer(ctx, args);
+        println!("START FP");
+        frame = get_caller_by_frame_pointer(ctx, args).await;
     }
     if frame.is_none() {
+        println!("START SCAN");
         frame = get_caller_by_scan(ctx, args).await;
     }
     let mut frame = frame?;


### PR DESCRIPTION
Currently on `amd64` frame pointer resolution is not even attempted on Windows, because the `%rbp` can point into the 'middle' of the frame.

This does have a huge downside, if there are frame pointers, we're not even trying to consider them. This is especially bad for JIT code, where native frames may not have frame pointers but code emitted by the JIT could have them. It appears that this is what Unity does.

But instead of just not attempting it, we can do better. We still know that the given `%rbp` is guaranteed lower than the return address and given by [windows docs](https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64) and e.g. the [goblin](https://github.com/m4b/goblin/blob/ac1fabdd2100bae949607a320fe5d8087c1e784a/src/pe/exception.rs#L560-L563) implementation.

```rs
        // The the scaled offset from RSP that is applied to the FP register when it's
        // established. The actual FP register is set to RSP + 16 * this number, allowing
        // offsets from 0 to 240.
        let frame_register_offset = u32::from((frame_info >> 4) * 16);
```

We know the frame pointer is off by `0..15*16` bytes. So we can extend the traditional frame pointer linked list logic with a slight variation that also scans the stack for a valid candidate.

This covers the case where the frame pointer is emitted as on other platforms, but also the windows case where it can be in the 'middle`.

While this is not perfect, this should still be a better heuristic than just simply scanning the stack (due to more strict constraints). Scanning the stack does remain the fallback if the frame pointer scan ends up failing.

Testing some variations of msvc with disabled frame pointer omission `/Oy-` and forcing the compiler to emit frame pointers due to the usage of `_alloca`, validates that the logic works.

For example on [godbolt](https://godbolt.org/z/Pjzj8vx5P):

```c
#include <stdlib.h>

void bar();

void foo(){
    volatile int *volatile a = _alloca(32);
    bar();
    *a = 2;
}
```

```asm
a$ = 0
__$ArrayPad$ = 8
foo     PROC
$LN3:
        push    rbp
        sub     rsp, 48                             ; 00000030H
        lea     rbp, QWORD PTR [rsp+32]
        mov     rax, QWORD PTR __security_cookie
        xor     rax, rbp
        mov     QWORD PTR __$ArrayPad$[rbp], rax
        mov     eax, DWORD PTR [rsp]
        mov     eax, 32                             ; 00000020H
        sub     rsp, rax
        lea     rax, QWORD PTR [rsp+32]
        mov     ecx, DWORD PTR [rax]
        mov     QWORD PTR a$[rbp], rax
        call    bar
        mov     rax, QWORD PTR a$[rbp]
        mov     DWORD PTR [rax], 2
        mov     rcx, QWORD PTR __$ArrayPad$[rbp]
        xor     rcx, rbp
        call    __security_check_cookie
        lea     rsp, QWORD PTR [rbp+16]
        pop     rbp
        ret     0
foo     ENDP
```

A real world example, with the patch:

```
Thread 0 (crashed)
  0  CrashApp.pdb!DoCrash(int, int) [CrashApp\CrashingProgram.cpp : 17]
      rax = 0x0000000000000000      rdx = 0x0000000000000003
      rcx = 0x00007ff7f3ad711d      rbx = 0x0000000000000000
      rsi = 0x0000000000000003      rdi = 0x0000000000000005
      rbp = 0x0000003b349fe8d0      rsp = 0x0000003b349fe8b0
       r8 = 0x0000000000000000       r9 = 0x000001810bc1c3d0
      r10 = 0x000001810e6e0000      r11 = 0x0000000000000000
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3a9fc36
     Found by: given as instruction pointer in context
  1  CrashApp.pdb!NativeAdd(int, int) [CrashApp\CrashingProgram.cpp : 23]
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349fea10      rsp = 0x0000003b349fe9f0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3aa5624
     Found by: call frame info
  2  0x1810e69de87
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349feb70      rsp = 0x0000003b349feaf0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x000001810e69de88
     Found by: call frame info
  3  0x1810d622932
      rbp = 0x0000003b349febe0      rsp = 0x0000003b349feb80
      rip = 0x000001810d622933
     Found by: previous frame's frame pointer
  4  0x1810d6225cf
      rbp = 0x0000003b349feca0      rsp = 0x0000003b349febf0
      rip = 0x000001810d6225d0
     Found by: previous frame's frame pointer
  5  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_jit_runtime_invoke(_MonoMethod*, void*, void**, _MonoObject**, _MonoError*) [C:\build\output\Unity-Technologies\mono\mono\mini\mini-runtime.c : 3445]
      rbp = 0x0000003b349fece0      rsp = 0x0000003b349fecb0
      rip = 0x00007ffad20169ce
     Found by: previous frame's frame pointer
  6  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!do_runtime_invoke(_MonoMethod*, void*, void**, _MonoObject**, _MonoError*) [C:\build\output\Unity-Technologies\mono\mono\metadata\object.c : 3066]
      rbx = 0x0000000000000000      rsi = 0x0000003b349ff218
      rdi = 0x000001810bc151e0      rbp = 0x0000000000000000
      rsp = 0x0000003b349fef60      r12 = 0x0000000000000000
      r13 = 0x0000000000000000      r14 = 0x0000003b349fefe0
      r15 = 0x000001810d872fd0      rip = 0x00007ffad1f58474
     Found by: call frame info
  7  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_runtime_try_invoke(_MonoMethod*, void*, void**, _MonoObject**, _MonoError*) [C:\build\output\Unity-Technologies\mono\mono\metadata\object.c : 3175]
     Found by: inlined into next frame
  8  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_runtime_invoke(_MonoMethod*, void*, void**, _MonoObject**) [C:\build\output\Unity-Technologies\mono\mono\metadata\object.c : 3115]
      rbx = 0x0000000000000010      rsi = 0x000001810bc151e0
      rdi = 0x0000003b349ff218      rbp = 0x0000003b349ff0d0
      rsp = 0x0000003b349fefb0      r12 = 0x0000000000000000
      r13 = 0x0000000000000000      r14 = 0x0000000000000000
      r15 = 0x0000000000000000      rip = 0x00007ffad1f58560
     Found by: call frame info
```

Without the patch:

```
0  CrashApp.pdb!DoCrash(int, int) [CrashApp\CrashingProgram.cpp : 17]
      rax = 0x0000000000000000      rdx = 0x0000000000000003
      rcx = 0x00007ff7f3ad711d      rbx = 0x0000000000000000
      rsi = 0x0000000000000003      rdi = 0x0000000000000005
      rbp = 0x0000003b349fe8d0      rsp = 0x0000003b349fe8b0
       r8 = 0x0000000000000000       r9 = 0x000001810bc1c3d0
      r10 = 0x000001810e6e0000      r11 = 0x0000000000000000
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3a9fc36
     Found by: given as instruction pointer in context
  1  CrashApp.pdb!NativeAdd(int, int) [CrashApp\CrashingProgram.cpp : 23]
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349fea10      rsp = 0x0000003b349fe9f0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3aa5624
     Found by: call frame info
  2  0x1810e69de87
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349feb70      rsp = 0x0000003b349feaf0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x000001810e69de88
     Found by: call frame info
  3  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_create_ftnptr(_MonoDomain*, void*) [C:\build\output\Unity-Technologies\mono\mono\metadata\object.c : 9364]
     Found by: inlined into next frame
  4  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_jit_compile_method_with_opt(_MonoMethod*, unsigned int, int, _MonoError*) [C:\build\output\Unity-Technologies\mono\mono\mini\mini-runtime.c : 2612]
      rsp = 0x0000003b349febc0      rip = 0x00007ffad2014472
     Found by: stack scanning
```

The stack scanning ends up finding a bogus frame and gets mislead, because the available frame pointers are not considered.