### PR TITLE
Downgrade linux maps log to warn

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -2560,7 +2560,7 @@ impl<'a> MinidumpStream<'a> for MinidumpLinuxMaps<'a> {
         _system_info: Option<&MinidumpSystemInfo>,
     ) -> Result<MinidumpLinuxMaps<'a>, Error> {
         let maps = MemoryMaps::from_read(std::io::Cursor::new(bytes)).map_err(|e| {
-            tracing::error!("linux memory map read error: {e}");
+            tracing::warn!("linux memory map read error: {e}");
             Error::StreamReadFailure
         })?;
 


### PR DESCRIPTION
We have a bunch of minidumps coming in now with an invalid linux maps section, which logs quite a few error, but minidump processing ignores the section just anyways: https://github.com/rust-minidump/rust-minidump/blob/39485c0e61ba14af468d04e560518df6c123900c/minidump-processor/src/processor.rs#L594