### PR TITLE
Bug 1978423 - Return an error from fill_symbol when symbols are disabled

### DIFF
--- a/minidump-unwind/src/symbols/debuginfo.rs
+++ b/minidump-unwind/src/symbols/debuginfo.rs
@@ -146,7 +146,7 @@ trait SymbolInterface {
     ) -> Result<(), FillSymbolError>;
 }
 
-/// A SymbolInterface that always returns `Ok(())` without doing anything.
+/// A SymbolInterface that always returns `Err(FillSymbolError {})` without doing anything.
 struct NoSymbols;
 
 #[async_trait]
@@ -156,7 +156,7 @@ impl SymbolInterface for NoSymbols {
         _module: &(dyn Module + Sync),
         _frame: &mut (dyn FrameSymbolizer + Send),
     ) -> Result<(), FillSymbolError> {
-        Ok(())
+        Err(FillSymbolError {})
     }
 }
 


### PR DESCRIPTION
When a success is returned, it causes stack scanning logic to go down this path:

https://github.com/rust-minidump/rust-minidump/blob/39485c0e61ba14af468d04e560518df6c123900c/minidump-unwind/src/lib.rs#L870

which requires the frame to have a symbol populated to proceed with stack scanning. Returning an error will allow stack scanning to proceed (which is more than likely desirable if you have symbols disabled).