### PR TITLE
Add riscv64 support for minidump and minidump-common

### DIFF
--- a/minidump-common/src/format.rs
+++ b/minidump-common/src/format.rs
@@ -786,8 +786,8 @@ bitflags! {
     /// CPU type values in the `context_flags` member of `CONTEXT_` structs
     ///
     /// This applies to the [`CONTEXT_ARM`], [`CONTEXT_PPC`], [`CONTEXT_MIPS`],
-    /// [`CONTEXT_AMD64`], [`CONTEXT_ARM64`], [`CONTEXT_PPC64`], [`CONTEXT_SPARC`] and
-    /// [`CONTEXT_ARM64_OLD`] structs.
+    /// [`CONTEXT_AMD64`], [`CONTEXT_ARM64`], [`CONTEXT_PPC64`], [`CONTEXT_SPARC`]
+    /// [`CONTEXT_RISCV64`] and [`CONTEXT_ARM64_OLD`] structs.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ContextFlagsCpu: u32 {
         const CONTEXT_IA64 = 0x80000;
@@ -810,6 +810,7 @@ bitflags! {
         const CONTEXT_PPC64 = 0x1000000;
         const CONTEXT_SPARC = 0x10000000;
         const CONTEXT_X86 = 0x10000;
+        const CONTEXT_RISCV64 = 0x08000000;
     }
 }
 
@@ -913,6 +914,18 @@ bitflags! {
         const CONTEXT_ARM_DEBUG_REGISTERS = 0x00000008 | ContextFlagsCpu::CONTEXT_ARM.bits();
         const CONTEXT_ARM_FULL = Self::CONTEXT_ARM_CONTROL.bits() | Self::CONTEXT_ARM_INTEGER.bits() | Self::CONTEXT_ARM_FLOATING_POINT.bits();
         const CONTEXT_ARM_ALL = Self::CONTEXT_ARM_FULL.bits() | Self::CONTEXT_ARM_DEBUG_REGISTERS.bits();
+    }
+}
+
+bitflags! {
+    /// Flags available for use in [`CONTEXT_RISCV.context_flags`]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ContextFlagsRiscv64: u32 {
+        // Yes, breakpad never defined CONTROL for this context
+
+        const CONTEXT_RISCV64_INTEGER = 0x00000001 | ContextFlagsCpu::CONTEXT_RISCV64.bits();
+        const CONTEXT_RISCV64_FLOATING_POINT = 0x00000002 | ContextFlagsCpu::CONTEXT_RISCV64.bits();
+        const CONTEXT_RISCV64_FULL = Self::CONTEXT_RISCV64_INTEGER.bits() | Self::CONTEXT_RISCV64_FLOATING_POINT.bits();
     }
 }
 
@@ -1410,6 +1423,59 @@ pub struct CONTEXT_X86 {
     pub extended_registers: [u8; 512], // MAXIMUM_SUPPORTED_EXTENSION
 }
 
+/// RISC-V64 floating point state
+#[derive(Debug, Default, Clone, Pread, Pwrite, SizeWith)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct FLOATING_SAVE_AREA_RISCV64 {
+    pub fpregs: [u64; 32],
+    pub fpcsr: u32,
+}
+
+/// A RISC-V64 CPU context
+///
+/// This is a Breakpad extension, as there is no definition of `CONTEXT` for RISC-V in WinNT.h.
+#[derive(Debug, Default, Clone, Pread, Pwrite, SizeWith)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct CONTEXT_RISCV64 {
+    pub context_flags: u32,
+    pub version: u32,
+
+    pub pc: u64,
+    pub ra: u64,
+    pub sp: u64,
+    pub gp: u64,
+    pub tp: u64,
+    pub t0: u64,
+    pub t1: u64,
+    pub t2: u64,
+    pub s0: u64,
+    pub s1: u64,
+    pub a0: u64,
+    pub a1: u64,
+    pub a2: u64,
+    pub a3: u64,
+    pub a4: u64,
+    pub a5: u64,
+    pub a6: u64,
+    pub a7: u64,
+    pub s2: u64,
+    pub s3: u64,
+    pub s4: u64,
+    pub s5: u64,
+    pub s6: u64,
+    pub s7: u64,
+    pub s8: u64,
+    pub s9: u64,
+    pub s10: u64,
+    pub s11: u64,
+    pub t3: u64,
+    pub t4: u64,
+    pub t5: u64,
+    pub t6: u64,
+
+    pub float_save: FLOATING_SAVE_AREA_RISCV64,
+}
+
 /// CPU information contained within the [`MINIDUMP_SYSTEM_INFO`] struct
 ///
 /// This struct matches the definition of the `CPU_INFORMATION` union from minidumpapiset.h.
@@ -1514,6 +1580,10 @@ pub enum ProcessorArchitecture {
     PROCESSOR_ARCHITECTURE_ARM64_OLD = 0x8003,
     /// Breakpad-defined value for MIPS64
     PROCESSOR_ARCHITECTURE_MIPS64 = 0x8004,
+    /// Breakpad-defined value for RISC-V
+    PROCESSOR_ARCHITECTURE_RISCV = 0x8005,
+    /// Breakpad-defined value for RISC-V64
+    PROCESSOR_ARCHITECTURE_RISCV64 = 0x8006,
     PROCESSOR_ARCHITECTURE_UNKNOWN = 0xffff,
 }
 

--- a/minidump-unwind/src/lib.rs
+++ b/minidump-unwind/src/lib.rs
@@ -518,7 +518,7 @@ impl CallStack {
                 use MinidumpRawContext::*;
                 let pointer_width = match &frame.context.raw {
                     X86(_) | Ppc(_) | Sparc(_) | Arm(_) | Mips(_) => 4,
-                    Ppc64(_) | Amd64(_) | Arm64(_) | OldArm64(_) => 8,
+                    Ppc64(_) | Amd64(_) | Arm64(_) | OldArm64(_) | Riscv64(_) => 8,
                 };
 
                 let cc_summary = match args.calling_convention {

--- a/minidump/src/system_info.rs
+++ b/minidump/src/system_info.rs
@@ -96,6 +96,7 @@ pub enum Cpu {
     Arm64,
     Mips,
     Mips64,
+    Riscv64,
     Unknown(u16),
 }
 
@@ -124,6 +125,7 @@ impl Cpu {
             }
             Some(PROCESSOR_ARCHITECTURE_MIPS) => Cpu::Mips,
             Some(PROCESSOR_ARCHITECTURE_MIPS64) => Cpu::Mips64,
+            Some(PROCESSOR_ARCHITECTURE_RISCV64) => Cpu::Riscv64,
             _ => Cpu::Unknown(arch),
         }
     }
@@ -132,7 +134,9 @@ impl Cpu {
     pub fn pointer_width(&self) -> PointerWidth {
         match self {
             Cpu::X86 | Cpu::Ppc | Cpu::Sparc | Cpu::Arm | Cpu::Mips => PointerWidth::Bits32,
-            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 | Cpu::Mips64 => PointerWidth::Bits64,
+            Cpu::X86_64 | Cpu::Ppc64 | Cpu::Arm64 | Cpu::Mips64 | Cpu::Riscv64 => {
+                PointerWidth::Bits64
+            }
             Cpu::Unknown(_) => PointerWidth::Unknown,
         }
     }
@@ -153,6 +157,7 @@ impl fmt::Display for Cpu {
                 Cpu::Arm64 => "arm64",
                 Cpu::Mips => "mips",
                 Cpu::Mips64 => "mips64",
+                Cpu::Riscv64 => "riscv64",
                 Cpu::Unknown(_) => "unknown",
             }
         )


### PR DESCRIPTION
Extracted from https://github.com/rust-minidump/rust-minidump/pull/941, this allows porting of minidump-writer to riscv64 (along with https://github.com/EmbarkStudios/crash-handling/pull/102).