### PR TITLE
Fix panic with malformed minidumps when reading object info

### DIFF
--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -1780,18 +1780,21 @@ impl MinidumpHandleDescriptor {
         offset: usize,
         ctx: HandleDescriptorContext,
     ) -> Option<MinidumpHandleObjectInformation> {
-        if offset != 0 {
-            ctx.bytes
-                .pread_with::<md::MINIDUMP_HANDLE_OBJECT_INFORMATION>(offset, ctx.endianess)
-                .ok()
-                .map(|raw| MinidumpHandleObjectInformation {
-                    raw: raw.clone(),
-                    info_type: md::MINIDUMP_HANDLE_OBJECT_INFORMATION_TYPE::from_u32(raw.info_type)
-                        .unwrap(),
-                })
-        } else {
-            None
+        if offset == 0 {
+            return None;
         }
+
+        ctx.bytes
+            .pread_with::<md::MINIDUMP_HANDLE_OBJECT_INFORMATION>(offset, ctx.endianess)
+            .ok()
+            .and_then(|raw| {
+                Some(MinidumpHandleObjectInformation {
+                    raw: raw.clone(),
+                    info_type: md::MINIDUMP_HANDLE_OBJECT_INFORMATION_TYPE::from_u32(
+                        raw.info_type,
+                    )?,
+                })
+            })
     }
 }
 


### PR DESCRIPTION
We encountered this panic in production, with a customer sent minidump. This treats the object info as missing if it is unknown/invalid. Maybe we should handle this with a separate error, but this looks fine to me (?).

[Sentry Issue](https://sentry.my.sentry.io/share/issue/31715566fd874e06a8dc8d4ccde813ce/) with stacktrace (note: need to click to show non in app frames).