### PR TITLE
Fix 1.91 clippy lints

### DIFF
--- a/breakpad-symbols/src/http.rs
+++ b/breakpad-symbols/src/http.rs
@@ -447,7 +447,7 @@ pub fn unpack_cabinet_file(
 
     // And swap it into the cache
     temp.persist_noclobber(&final_cache_path)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(std::io::Error::other)?;
 
     Ok(final_cache_path)
 }

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -712,7 +712,7 @@ fn location_slice<'a>(
 fn read_string_utf16(offset: &mut usize, bytes: &[u8], endian: scroll::Endian) -> Option<String> {
     let u: u32 = bytes.gread_with(offset, endian).ok()?;
     let size = u as usize;
-    if size % 2 != 0 || (*offset + size) > bytes.len() {
+    if !size.is_multiple_of(2) || (*offset + size) > bytes.len() {
         return None;
     }
     let encoding = match endian {


### PR DESCRIPTION
Fixed with: `cargo clippy --workspace --all-targets --no-deps --all-features --fix`