### PR TITLE
processor: bitflip: add a detractor with off-by-one detection heuristics

### DIFF
--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -751,8 +751,20 @@ impl<'a> MinidumpInfo<'a> {
         };
         if let Some((address, bit_range)) = bit_flip_address {
             let memory_op = MemoryOperation::from_crash_reason(&info.reason);
+            let access = info.memory_access_list.as_ref().and_then(|list| {
+                list.iter().find(|access| {
+                    let size = access.size.unwrap_or_default();
+                    let base = access.address_info.address;
+                    (base..base.saturating_add(size as u64)).contains(&info.address.0)
+                })
+            });
+
+            // If we have a crashing memory access, use the base address for
+            // bitflip heuristics, as the exception address would just be a
+            // derivative of it.
+            let access_address = access.map(|a| a.address_info.address).unwrap_or(address);
             info.possible_bit_flips = bitflip::try_bit_flips(
-                address,
+                access_address,
                 None,
                 bit_range,
                 exception_details.context.as_deref(),

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -763,6 +763,10 @@ impl<'a> MinidumpInfo<'a> {
             // bitflip heuristics, as the exception address would just be a
             // derivative of it.
             let access_address = access.map(|a| a.address_info.address).unwrap_or(address);
+            // The size of the access that actually faulted, used to gauge whether the crash looks
+            // like an off-by-one rather than a bit flip.
+            let memory_access_size = access.and_then(|a| a.size);
+
             info.possible_bit_flips = bitflip::try_bit_flips(
                 access_address,
                 None,
@@ -770,6 +774,7 @@ impl<'a> MinidumpInfo<'a> {
                 exception_details.context.as_deref(),
                 &self.memory_info,
                 memory_op,
+                memory_access_size,
             );
 
             // If we have an exception context, we can check the registers involved in the
@@ -788,6 +793,7 @@ impl<'a> MinidumpInfo<'a> {
                             // the base address, possibly combined with some offset, is still in
                             // the same memory region).
                             memory_op,
+                            memory_access_size,
                         ));
                     }
                 }
@@ -1508,6 +1514,7 @@ mod bitflip {
         exception_context: Option<&MinidumpContext>,
         memory_info: &UnifiedMemoryInfoList,
         memory_operation: MemoryOperation,
+        memory_access_size: Option<u8>,
     ) -> Vec<PossibleBitFlip> {
         let mut addresses = Vec::new();
         // If the address maps to valid memory, don't do anything else.
@@ -1515,6 +1522,18 @@ mod bitflip {
             if memory_operation.is_possibly_allowed_for(&mi) {
                 return addresses;
             }
+        }
+
+        // The address does not map to accessible memory. Measure how far it is from the nearest
+        // allocation: a fault landing right next to one is more likely an off-by-one than a bit
+        // flip (see `BitFlipDetails::confidence`).
+        let distance_to_closest_mapping =
+            distance_to_closest_mapping(address, memory_operation, memory_info);
+
+        // Quick check for obvious off-by-one
+        match (distance_to_closest_mapping, memory_access_size) {
+            (Some(distance), Some(access)) if distance < access as u64 => return addresses,
+            _ => (),
         }
 
         let create_possible_address = |new_address: u64| {
@@ -1542,5 +1561,27 @@ mod bitflip {
         }
 
         addresses
+    }
+
+    /// Return the distance from `address` to the nearest accessible (allocated) memory region, in
+    /// either direction, or `None` if there are no accessible regions.
+    fn distance_to_closest_mapping(
+        address: u64,
+        operation: MemoryOperation,
+        memory_info: &UnifiedMemoryInfoList,
+    ) -> Option<u64> {
+        memory_info
+            .by_addr()
+            .filter(|r| operation.is_possibly_allowed_for(r))
+            .filter_map(|region| {
+                let range = region.memory_range()?;
+                // `memory_range` has an inclusive end.
+                Some(if address < range.start {
+                    range.start - address
+                } else {
+                    address.saturating_sub(range.end)
+                })
+            })
+            .min()
     }
 }

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -549,3 +549,76 @@ async fn test_guard_pages() {
     assert_eq!(access_list.accesses[0].address_info.address, 0x81000);
     assert!(access_list.accesses[0].address_info.is_likely_guard_page);
 }
+
+// Test cross-page boundary access: base address is valid but access crosses into invalid page.
+// With the new code that uses the actual access address from memory operations,
+// bitflip detection correctly identifies this as a non-bitflip (boundary crossing) crash.
+#[cfg_attr(
+    not(feature = "disasm_amd64"),
+    ignore = "requires disassembly for access size"
+)]
+#[tokio::test]
+async fn test_no_bit_flip_cross_page_boundary() {
+    let context = minidump_synth::amd64_context(Endian::Little, 0x2000, 0xfff9);
+
+    // `mov rax, [rsp]`: an eight-byte read through rsp at 0xfff9
+    // This crosses from 0xfff9-0xffff (valid) into 0x10000+ (invalid)
+    let memory = Memory::with_section(
+        Section::with_endian(Endian::Little).append_bytes(&[0x48, 0x8b, 0x04, 0x24]),
+        0x2000,
+    );
+    let stack = Memory::with_section(Section::with_endian(Endian::Little), 0x1000);
+
+    // Heap region [0x0, 0x10000) - one page
+    let heap_info = MemoryInfo::new(
+        Endian::Little,
+        0x0,
+        0x0,
+        0,
+        0x10000,
+        0,
+        MemoryProtection::PAGE_EXECUTE_READWRITE.bits(),
+        0,
+    );
+
+    let thread = Thread::new(Endian::Little, 1, &stack, &context);
+    let system_info = SystemInfo::new(Endian::Little).set_processor_architecture(
+        minidump_common::format::ProcessorArchitecture::PROCESSOR_ARCHITECTURE_AMD64 as u16,
+    );
+
+    let context_label = context.file_offset();
+    let context_size = context.file_size();
+
+    let dump = SynthMinidump::with_endian(Endian::Little).add(context);
+
+    let mut ex = Exception::new(Endian::Little);
+    ex.thread_id = 1;
+    // Fault occurs at the invalid page (0x10000), but access base was at 0xfff9 (valid)
+    ex.exception_record.exception_address = 0x10000;
+    ex.thread_context = (
+        context_size.value().unwrap() as u32,
+        context_label.value().unwrap() as u32,
+    );
+
+    let dump = dump
+        .add_thread(thread)
+        .add_exception(ex)
+        .add_system_info(system_info)
+        .add_memory(memory)
+        .add_memory(stack)
+        .add_memory_info(heap_info);
+
+    let state = read_synth_dump(dump).await;
+
+    let bit_flips = state
+        .exception_info
+        .expect("missing exception info")
+        .possible_bit_flips;
+
+    // No bitflips should be detected because the access address (0xfff9) is valid.
+    // The segfault is from crossing a page boundary, not a bitflip.
+    assert!(
+        bit_flips.is_empty(),
+        "expected no bit flips for valid access address crossing page boundary"
+    );
+}

--- a/minidump-processor/tests/test_processor.rs
+++ b/minidump-processor/tests/test_processor.rs
@@ -622,3 +622,71 @@ async fn test_no_bit_flip_cross_page_boundary() {
         "expected no bit flips for valid access address crossing page boundary"
     );
 }
+
+// Test an obvious off-by-one: the faulting access lands just past the end of a valid mapping,
+// closer than the size of the access itself. It should not produce any possible bitflip.
+#[cfg_attr(
+    not(feature = "disasm_amd64"),
+    ignore = "requires disassembly for access size"
+)]
+#[tokio::test]
+async fn test_no_bit_flip_obvious_off_by_one() {
+    // rip = 0x2000, rsp = 0x90001 (the access base, just past the end of the heap region below)
+    let context = minidump_synth::amd64_context(Endian::Little, 0x2000, 0x90001);
+
+    // `mov rax, [rsp]`: an eight-byte read through rsp at 0x90001.
+    let memory = Memory::with_section(
+        Section::with_endian(Endian::Little).append_bytes(&[0x48, 0x8b, 0x04, 0x24]),
+        0x2000,
+    );
+    let stack = Memory::with_section(Section::with_endian(Endian::Little), 0x1000);
+
+    // Heap region [0x80000, 0x90000) - one page. Its inclusive end is 0x8ffff, so the access at
+    // 0x90001 is only two bytes past the mapping, well within the eight-byte access size.
+    let heap_info = MemoryInfo::new(
+        Endian::Little,
+        0x80000,
+        0x80000,
+        0,
+        0x10000,
+        0,
+        MemoryProtection::PAGE_EXECUTE_READWRITE.bits(),
+        0,
+    );
+
+    let thread = Thread::new(Endian::Little, 1, &stack, &context);
+    let system_info = SystemInfo::new(Endian::Little).set_processor_architecture(
+        minidump_common::format::ProcessorArchitecture::PROCESSOR_ARCHITECTURE_AMD64 as u16,
+    );
+
+    let context_label = context.file_offset();
+    let context_size = context.file_size();
+
+    let dump = SynthMinidump::with_endian(Endian::Little).add(context);
+
+    let mut ex = Exception::new(Endian::Little);
+    ex.thread_id = 1;
+    // The fault is within the (invalid) access range [0x90001, 0x90009).
+    ex.exception_record.exception_address = 0x90001;
+    ex.thread_context = (
+        context_size.value().unwrap() as u32,
+        context_label.value().unwrap() as u32,
+    );
+
+    let dump = dump
+        .add_thread(thread)
+        .add_exception(ex)
+        .add_system_info(system_info)
+        .add_memory(memory)
+        .add_memory(stack)
+        .add_memory_info(heap_info);
+
+    let state = read_synth_dump(dump).await;
+
+    let bit_flips = state
+        .exception_info
+        .expect("missing exception info")
+        .possible_bit_flips;
+
+    assert!(bit_flips.is_empty());
+}


### PR DESCRIPTION
When we're reasonably sure the segfault is caused by the common off-by-one programmer error, we can lower the bitflip confidence score to make developers have a second look.

Closes #960