### PR TITLE
Fix ARM64 FP unwind LR preservation for entry CFI

### DIFF
--- a/breakpad-symbols/src/lib.rs
+++ b/breakpad-symbols/src/lib.rs
@@ -603,6 +603,9 @@ pub trait FrameWalker {
     fn set_cfa(&mut self, val: u64) -> Option<()>;
     /// Set whatever registers in the caller should be set based on the return address (e.g. rip).
     fn set_ra(&mut self, val: u64) -> Option<()>;
+    /// Report where the CFI rule range covering the instruction begins
+    /// (the `STACK CFI INIT` row's start address).
+    fn set_cfi_rules_start_address(&mut self, _addr: Option<u64>) {}
 }
 
 /// A simple implementation of `FrameSymbolizer` that just holds data.

--- a/breakpad-symbols/src/sym_file/mod.rs
+++ b/breakpad-symbols/src/sym_file/mod.rs
@@ -514,7 +514,13 @@ impl SymbolFile {
                     count += 1;
                 }
 
-                walker::walk_with_stack_cfi(&info.init, &info.add_rules[0..count], walker)
+                walker.set_cfi_rules_start_address(Some(module.base_address() + info.init.address));
+                let result =
+                    walker::walk_with_stack_cfi(&info.init, &info.add_rules[0..count], walker);
+                // Reset even on failure so the address cannot leak into
+                // another provider's evaluation.
+                walker.set_cfi_rules_start_address(None);
+                result
             } else {
                 None
             }

--- a/minidump-processor/src/processor.rs
+++ b/minidump-processor/src/processor.rs
@@ -867,27 +867,25 @@ impl<'a> MinidumpInfo<'a> {
             CrashReason::MacArithmeticPpc(MacArithPpc::EXC_PPC_ZERO_DIVIDE)
             | CrashReason::MacArithmeticX86(MacArithX86::EXC_I386_DIV)
             | CrashReason::LinuxSigfpe(LinuxSigfpe::FPE_INTDIV)
-            | CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_INT_DIVIDE_BY_ZERO) => {
+            | CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_INT_DIVIDE_BY_ZERO)
                 if exception_details
                     .info
                     .instruction_properties
                     .as_ref()
-                    .is_some_and(|p| !p.is_division)
-                {
-                    inconsistencies.push(Inconsistency::IntDivByZeroNotPossible);
-                }
+                    .is_some_and(|p| !p.is_division) =>
+            {
+                inconsistencies.push(Inconsistency::IntDivByZeroNotPossible);
             }
 
             CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_PRIV_INSTRUCTION)
-            | CrashReason::WindowsNtStatus(NtStatusWindows::STATUS_PRIVILEGED_INSTRUCTION) => {
+            | CrashReason::WindowsNtStatus(NtStatusWindows::STATUS_PRIVILEGED_INSTRUCTION)
                 if exception_details
                     .info
                     .instruction_properties
                     .as_ref()
-                    .is_some_and(|p| !p.is_privileged)
-                {
-                    inconsistencies.push(Inconsistency::PrivInstructionCrashWithoutPrivInstruction);
-                }
+                    .is_some_and(|p| !p.is_privileged) =>
+            {
+                inconsistencies.push(Inconsistency::PrivInstructionCrashWithoutPrivInstruction);
             }
 
             CrashReason::WindowsAccessViolation(WinAccess::READ) => {

--- a/minidump-unwind/src/arm64.rs
+++ b/minidump-unwind/src/arm64.rs
@@ -131,12 +131,11 @@ where
     // sp := fp + ptr*2
     // fp := *fp
     //
-    // Note that although we push lr, we don't restore lr. That's because lr is just our
-    // return address, and is therefore essentially a "saved" pc. lr is caller-saved *and*
-    // automatically overwritten by every CALL, so the callee (the frame we're unwinding right now)
-    // has no business ever knowing it, let alone restoring it. lr is generally just saved
-    // immediately and then used as a free general purpose register, and therefore will generally
-    // contain random garbage unrelated to unwinding.
+    // We also recover the caller's lr from its frame record when possible. lr is
+    // caller-saved and generally volatile while a function is running, but a
+    // non-leaf caller's frame record preserves the lr value it had on entry.
+    // Keeping that value valid lets later CFI rows like `.ra: x30` at a function
+    // entry recover the next caller.
     //
     //
     // # Leaf Functions
@@ -195,6 +194,14 @@ where
     };
     let caller_fp = ptr_auth_strip(args.modules, caller_fp);
     let caller_pc = ptr_auth_strip(args.modules, caller_pc);
+    let caller_lr = if caller_fp == 0 {
+        None
+    } else {
+        caller_fp
+            .checked_add(POINTER_WIDTH)
+            .and_then(|caller_lr_addr| args.stack_memory.get_memory_at_address(caller_lr_addr))
+            .map(|caller_lr| ptr_auth_strip(args.modules, caller_lr))
+    };
 
     // Don't accept obviously wrong instruction pointers.
     if is_non_canonical(caller_pc) {
@@ -214,11 +221,17 @@ where
     caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
     caller_ctx.set_register(FRAME_POINTER, caller_fp);
     caller_ctx.set_register(STACK_POINTER, caller_sp);
+    if let Some(caller_lr) = caller_lr {
+        caller_ctx.set_register(LINK_REGISTER, caller_lr);
+    }
 
     let mut valid = HashSet::new();
     valid.insert(PROGRAM_COUNTER);
     valid.insert(FRAME_POINTER);
     valid.insert(STACK_POINTER);
+    if caller_lr.is_some() {
+        valid.insert(LINK_REGISTER);
+    }
 
     let context = MinidumpContext {
         raw: MinidumpRawContext::Arm64(caller_ctx),
@@ -451,15 +464,20 @@ where
 
     let sp = frame.context.get_stack_pointer();
     let last_sp = ctx.get_register_always("sp");
-    if sp <= last_sp {
-        // Arm leaf functions may not actually touch the stack (thanks
-        // to the link register allowing you to "push" the return address
-        // to a register), so we need to permit the stack pointer to not
-        // change for the first frame of the unwind. After that we need
-        // more strict validation to avoid infinite loops.
-        let is_leaf = args.callee_frame.trust == FrameTrust::Context && sp == last_sp;
-        if !is_leaf {
-            trace!("stack pointer went backwards, assuming unwind complete");
+    if sp < last_sp {
+        trace!("stack pointer went backwards, assuming unwind complete");
+        return None;
+    }
+    if sp == last_sp {
+        // Arm leaf functions and function-entry CFI may leave sp unchanged.
+        // Require the instruction pointer to change so this allowance cannot
+        // trivially repeat the same frame forever.
+        let caller_pc = frame.context.get_instruction_pointer();
+        let callee_pc = ctx.get_register_always(PROGRAM_COUNTER);
+        let is_context_leaf = args.callee_frame.trust == FrameTrust::Context;
+        let is_cfi_entry = frame.trust == FrameTrust::CallFrameInfo;
+        if caller_pc == callee_pc || !(is_context_leaf || is_cfi_entry) {
+            trace!("stack pointer did not advance, assuming unwind complete");
             return None;
         }
     }

--- a/minidump-unwind/src/arm64.rs
+++ b/minidump-unwind/src/arm64.rs
@@ -37,6 +37,7 @@ where
     let _last_sp = ctx.get_register(STACK_POINTER, args.valid())?;
 
     let mut stack_walker = CfiStackWalker::from_ctx_and_args(ctx, args, callee_forwarded_regs)?;
+    stack_walker.callee_lr_is_heuristic = args.callee_frame.trust == FrameTrust::FramePointer;
 
     args.symbol_provider
         .walk_frame(stack_walker.module, &mut stack_walker)

--- a/minidump-unwind/src/arm64_old.rs
+++ b/minidump-unwind/src/arm64_old.rs
@@ -37,6 +37,7 @@ where
     let _last_sp = ctx.get_register(STACK_POINTER, args.valid())?;
 
     let mut stack_walker = CfiStackWalker::from_ctx_and_args(ctx, args, callee_forwarded_regs)?;
+    stack_walker.callee_lr_is_heuristic = args.callee_frame.trust == FrameTrust::FramePointer;
 
     args.symbol_provider
         .walk_frame(stack_walker.module, &mut stack_walker)

--- a/minidump-unwind/src/arm64_old.rs
+++ b/minidump-unwind/src/arm64_old.rs
@@ -131,12 +131,11 @@ where
     // sp := fp + ptr*2
     // fp := *fp
     //
-    // Note that although we push lr, we don't restore lr. That's because lr is just our
-    // return address, and is therefore essentially a "saved" pc. lr is caller-saved *and*
-    // automatically overwritten by every CALL, so the callee (the frame we're unwinding right now)
-    // has no business ever knowing it, let alone restoring it. lr is generally just saved
-    // immediately and then used as a free general purpose register, and therefore will generally
-    // contain random garbage unrelated to unwinding.
+    // We also recover the caller's lr from its frame record when possible. lr is
+    // caller-saved and generally volatile while a function is running, but a
+    // non-leaf caller's frame record preserves the lr value it had on entry.
+    // Keeping that value valid lets later CFI rows like `.ra: x30` at a function
+    // entry recover the next caller.
     //
     //
     // # Leaf Functions
@@ -195,6 +194,14 @@ where
     };
     let caller_fp = ptr_auth_strip(args.modules, caller_fp);
     let caller_pc = ptr_auth_strip(args.modules, caller_pc);
+    let caller_lr = if caller_fp == 0 {
+        None
+    } else {
+        caller_fp
+            .checked_add(POINTER_WIDTH)
+            .and_then(|caller_lr_addr| args.stack_memory.get_memory_at_address(caller_lr_addr))
+            .map(|caller_lr| ptr_auth_strip(args.modules, caller_lr))
+    };
 
     // Don't accept obviously wrong instruction pointers.
     if is_non_canonical(caller_pc) {
@@ -214,11 +221,17 @@ where
     caller_ctx.set_register(PROGRAM_COUNTER, caller_pc);
     caller_ctx.set_register(FRAME_POINTER, caller_fp);
     caller_ctx.set_register(STACK_POINTER, caller_sp);
+    if let Some(caller_lr) = caller_lr {
+        caller_ctx.set_register(LINK_REGISTER, caller_lr);
+    }
 
     let mut valid = HashSet::new();
     valid.insert(PROGRAM_COUNTER);
     valid.insert(FRAME_POINTER);
     valid.insert(STACK_POINTER);
+    if caller_lr.is_some() {
+        valid.insert(LINK_REGISTER);
+    }
 
     let context = MinidumpContext {
         raw: MinidumpRawContext::OldArm64(caller_ctx),
@@ -451,15 +464,20 @@ where
 
     let sp = frame.context.get_stack_pointer();
     let last_sp = ctx.get_register_always("sp");
-    if sp <= last_sp {
-        // Arm leaf functions may not actually touch the stack (thanks
-        // to the link register allowing you to "push" the return address
-        // to a register), so we need to permit the stack pointer to not
-        // change for the first frame of the unwind. After that we need
-        // more strict validation to avoid infinite loops.
-        let is_leaf = args.callee_frame.trust == FrameTrust::Context && sp == last_sp;
-        if !is_leaf {
-            trace!("stack pointer went backwards, assuming unwind complete");
+    if sp < last_sp {
+        trace!("stack pointer went backwards, assuming unwind complete");
+        return None;
+    }
+    if sp == last_sp {
+        // Arm leaf functions and function-entry CFI may leave sp unchanged.
+        // Require the instruction pointer to change so this allowance cannot
+        // trivially repeat the same frame forever.
+        let caller_pc = frame.context.get_instruction_pointer();
+        let callee_pc = ctx.get_register_always(PROGRAM_COUNTER);
+        let is_context_leaf = args.callee_frame.trust == FrameTrust::Context;
+        let is_cfi_entry = frame.trust == FrameTrust::CallFrameInfo;
+        if caller_pc == callee_pc || !(is_context_leaf || is_cfi_entry) {
+            trace!("stack pointer did not advance, assuming unwind complete");
             return None;
         }
     }

--- a/minidump-unwind/src/arm64_unittest.rs
+++ b/minidump-unwind/src/arm64_unittest.rs
@@ -561,6 +561,119 @@ async fn test_frame_pointer_preserves_lr_for_entry_cfi() {
 }
 
 #[tokio::test]
+async fn test_frame_pointer_lr_whole_function_leaf_cfi() {
+    // Mirrors macOS symbol files, where CFI is derived from compact unwind
+    // info: every function is covered by exactly one whole-function row with
+    // no prologue deltas. Stackless-leaf encodings (and merged adjacent stub
+    // ranges from `CompactUnwindOp::None`, e.g. syscall stubs in
+    // libsystem_kernel.dylib) produce rows like:
+    //
+    //     STACK CFI INIT 2000 100 .cfa: sp .ra: x30
+    //
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let frame0_fp = Label::new();
+    let frame1_fp = Label::new();
+    let frame2_fp = Label::new();
+    let frame3_fp = Label::new();
+    // All return addresses are mid-function: the whole-function rows apply at
+    // every offset, not just at the entry point.
+    let return_address1 = 0x40002044u64;
+    let return_address2 = 0x40003044u64;
+    let return_address3 = 0x40004044u64;
+
+    stack = stack
+        // frame 0 (callee): no CFI coverage, unwinds by frame pointer.
+        .append_repeated(0, 64)
+        .mark(&frame0_fp)
+        .D64(&frame1_fp)
+        .D64(return_address1)
+        // frame 1 (merged_stub): a normal frame covered by a bogus
+        // whole-function stackless-leaf row.
+        .append_repeated(0, 64)
+        .mark(&frame1_fp)
+        .D64(&frame2_fp)
+        .D64(return_address2)
+        // frame 2 (frame_caller): honest frame-based CFI.
+        .append_repeated(0, 64)
+        .mark(&frame2_fp)
+        .D64(&frame3_fp)
+        .D64(return_address3)
+        // frame 3 (outer): end of the chain.
+        .append_repeated(0, 64)
+        .mark(&frame3_fp)
+        .D64(0)
+        .D64(0)
+        .append_repeated(0, 64);
+
+    f.raw.set_register("pc", 0x40001010);
+    f.raw.set_register("fp", frame0_fp.value().unwrap());
+    f.raw.set_register("sp", stack.start().value().unwrap());
+    f.raw.set_register("lr", 0x1fe0fe10);
+
+    f.add_symbols(
+        String::from("module1"),
+        [
+            "FUNC 1000 100 10 callee\n",
+            "FUNC 2000 100 10 merged_stub\n",
+            "STACK CFI INIT 2000 100 .cfa: sp .ra: x30\n",
+            "FUNC 3000 100 10 frame_caller\n",
+            "STACK CFI INIT 3000 100 .cfa: x29 16 + x29: .cfa -16 + ^ .ra: .cfa -8 + ^\n",
+            "FUNC 4000 100 10 outer\n",
+            "STACK CFI INIT 4000 100 .cfa: x29 16 + x29: .cfa -16 + ^ .ra: .cfa -8 + ^\n",
+        ]
+        .concat(),
+    );
+
+    let s = f.walk_stack(stack).await;
+
+    let pcs: Vec<u64> = s
+        .frames
+        .iter()
+        .map(|frame| frame.context.get_instruction_pointer())
+        .collect();
+    assert_eq!(
+        pcs,
+        vec![
+            0x40001010,
+            return_address1,
+            return_address2,
+            return_address3
+        ],
+        "each caller must appear exactly once"
+    );
+
+    assert_eq!(s.frames[0].trust, FrameTrust::Context);
+    assert_eq!(s.frames[1].trust, FrameTrust::FramePointer);
+    // merged_stub's leaf row must not evaluate mid-function; frame-pointer
+    // unwinding derives the caller from merged_stub's own frame record.
+    assert_eq!(s.frames[2].trust, FrameTrust::FramePointer);
+    assert_eq!(s.frames[3].trust, FrameTrust::CallFrameInfo);
+
+    {
+        let frame = &s.frames[2];
+        let valid = &frame.context.valid;
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(ctx.get_register("pc", valid).unwrap(), return_address2);
+            // sp must advance past merged_stub's frame record; the leaf row
+            // would have left it unchanged.
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_fp.value().unwrap() + 16
+            );
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame2_fp.value().unwrap()
+            );
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[tokio::test]
 async fn test_frame_pointer_stackless_leaf() {
     // Same as test_frame_pointer but frame0 is a stackless leaf.
     //

--- a/minidump-unwind/src/arm64_unittest.rs
+++ b/minidump-unwind/src/arm64_unittest.rs
@@ -408,7 +408,7 @@ async fn test_frame_pointer() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }
@@ -423,6 +423,7 @@ async fn test_frame_pointer() {
                 ctx.get_register("fp", valid).unwrap(),
                 frame1_fp.value().unwrap()
             );
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), return_address2);
         } else {
             unreachable!();
         }
@@ -434,7 +435,7 @@ async fn test_frame_pointer() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }
@@ -448,6 +449,110 @@ async fn test_frame_pointer() {
             assert_eq!(
                 ctx.get_register("fp", valid).unwrap(),
                 frame2_fp.value().unwrap()
+            );
+            assert_eq!(ctx.get_register("lr", valid).unwrap(), 0);
+        } else {
+            unreachable!();
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_frame_pointer_preserves_lr_for_entry_cfi() {
+    let mut f = TestFixture::new();
+    let mut stack = Section::new();
+    stack.start().set_const(0x80000000);
+
+    let frame0_fp = Label::new();
+    let frame1_sp = Label::new();
+    let frame1_fp = Label::new();
+    let caller_resume_address = 0x40002004u64;
+    let caller_instruction = caller_resume_address - 4;
+    let grandcaller_resume_address = 0x50000104u64;
+    let grandcaller_instruction = grandcaller_resume_address - 4;
+
+    stack = stack
+        // frame 0 unwinds by frame pointer into frame 1.
+        .append_repeated(0, 64)
+        .mark(&frame0_fp)
+        .D64(&frame1_fp)
+        .D64(caller_resume_address)
+        .mark(&frame1_sp)
+        // frame 1's frame record preserves the lr it had on entry.
+        .append_repeated(0, 64)
+        .mark(&frame1_fp)
+        .D64(0)
+        .D64(grandcaller_resume_address)
+        .append_repeated(0, 64);
+
+    f.raw.set_register("pc", 0x40001010);
+    f.raw.set_register("fp", frame0_fp.value().unwrap());
+    f.raw.set_register("sp", stack.start().value().unwrap());
+    f.raw.set_register("lr", 0x1fe0fe10);
+
+    f.add_symbols(
+        String::from("module1"),
+        [
+            "FUNC 1000 100 10 callee\n",
+            "FUNC 2000 100 10 caller\n",
+            "STACK CFI INIT 2000 100 .cfa: sp 0 + .ra: x30\n",
+        ]
+        .concat(),
+    );
+    f.add_symbols(
+        String::from("module2"),
+        [
+            "FUNC 100 100 10 grandcaller\n",
+            "STACK CFI INIT 100 100 .cfa: 0 .ra: 0\n",
+        ]
+        .concat(),
+    );
+
+    let s = f.walk_stack(stack).await;
+    assert_eq!(s.frames.len(), 3);
+
+    {
+        let frame = &s.frames[1];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::FramePointer);
+        assert_eq!(frame.instruction, caller_instruction);
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(
+                ctx.get_register("pc", valid).unwrap(),
+                caller_resume_address
+            );
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap()
+            );
+            assert_eq!(
+                ctx.get_register("fp", valid).unwrap(),
+                frame1_fp.value().unwrap()
+            );
+            assert_eq!(
+                ctx.get_register("lr", valid).unwrap(),
+                grandcaller_resume_address
+            );
+        } else {
+            unreachable!();
+        }
+    }
+
+    {
+        let frame = &s.frames[2];
+        let valid = &frame.context.valid;
+        assert_eq!(frame.trust, FrameTrust::CallFrameInfo);
+        assert_eq!(frame.instruction, grandcaller_instruction);
+
+        if let MinidumpRawContext::Arm64(ctx) = &frame.context.raw {
+            assert_eq!(
+                ctx.get_register("pc", valid).unwrap(),
+                grandcaller_resume_address
+            );
+            assert_eq!(
+                ctx.get_register("sp", valid).unwrap(),
+                frame1_sp.value().unwrap()
             );
         } else {
             unreachable!();
@@ -516,7 +621,7 @@ async fn test_frame_pointer_stackless_leaf() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }
@@ -595,7 +700,7 @@ async fn test_frame_pointer_stackful_leaf() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }
@@ -689,7 +794,7 @@ async fn test_frame_pointer_ptr_auth_strip() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }
@@ -715,7 +820,7 @@ async fn test_frame_pointer_ptr_auth_strip() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }
@@ -1335,7 +1440,7 @@ async fn test_frame_pointer_infinite_equality() {
         let valid = &frame.context.valid;
         assert_eq!(frame.trust, FrameTrust::FramePointer);
         if let MinidumpContextValidity::Some(ref which) = valid {
-            assert_eq!(which.len(), 3);
+            assert_eq!(which.len(), 4);
         } else {
             unreachable!();
         }

--- a/minidump-unwind/src/lib.rs
+++ b/minidump-unwind/src/lib.rs
@@ -557,9 +557,12 @@ struct CfiStackWalker<'a, C: CpuContext> {
 
     callee_ctx: &'a C,
     callee_validity: &'a MinidumpContextValidity,
+    callee_lr_is_heuristic: bool,
 
     caller_ctx: C,
     caller_validity: HashSet<&'static str>,
+
+    cfi_rules_start_address: Option<u64>,
 
     module: &'a MinidumpModule,
     stack_memory: UnifiedMemory<'a, 'a>,
@@ -588,12 +591,15 @@ where
 
             callee_ctx: ctx,
             callee_validity: args.valid(),
+            callee_lr_is_heuristic: false,
 
             // Default to forwarding all callee-saved regs verbatim.
             // The CFI evaluator may clear or overwrite these values.
             // The stack pointer and instruction pointer are not included.
             caller_ctx: ctx.clone(),
             caller_validity: callee_forwarded_regs(args.valid()),
+
+            cfi_rules_start_address: None,
 
             module,
             stack_memory: args.stack_memory,
@@ -622,6 +628,12 @@ where
         result.and_then(|val| u64::try_from(val).ok())
     }
     fn get_callee_register(&self, name: &str) -> Option<u64> {
+        if self.callee_lr_is_heuristic
+            && matches!(name, "lr" | "x30")
+            && self.cfi_rules_start_address != Some(self.instruction)
+        {
+            return None;
+        }
         self.callee_ctx
             .get_register(name, self.callee_validity)
             .and_then(|val| u64::try_from(val).ok())
@@ -648,6 +660,9 @@ where
         let val = C::Register::try_from(val).ok()?;
         self.caller_validity.insert(instruction_pointer_reg);
         self.caller_ctx.set_register(instruction_pointer_reg, val)
+    }
+    fn set_cfi_rules_start_address(&mut self, addr: Option<u64>) {
+        self.cfi_rules_start_address = addr;
     }
 }
 

--- a/minidump/src/minidump.rs
+++ b/minidump/src/minidump.rs
@@ -4313,7 +4313,9 @@ impl CrashReason {
 
         // Refine the output for error codes that have more info
         match reason {
-            CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_ACCESS_VIOLATION) => {
+            CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_ACCESS_VIOLATION)
+                if record.number_parameters >= 1 =>
+            {
                 // For EXCEPTION_ACCESS_VIOLATION, Windows puts the address that
                 // caused the fault in exception_information[1].
                 // exception_information[0] is 0 if the violation was caused by
@@ -4321,14 +4323,14 @@ impl CrashReason {
                 // and 8 if this was a data execution violation.
                 // This information is useful in addition to the code address, which
                 // will be present in the crash thread's instruction field anyway.
-                if record.number_parameters >= 1 {
-                    // NOTE: address := info[1];
-                    if let Some(ty) = err::ExceptionCodeWindowsAccessType::from_u64(info[0]) {
-                        reason = CrashReason::WindowsAccessViolation(ty);
-                    }
+                // NOTE: address := info[1];
+                if let Some(ty) = err::ExceptionCodeWindowsAccessType::from_u64(info[0]) {
+                    reason = CrashReason::WindowsAccessViolation(ty);
                 }
             }
-            CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_IN_PAGE_ERROR) => {
+            CrashReason::WindowsGeneral(ExceptionCodeWindows::EXCEPTION_IN_PAGE_ERROR)
+                if record.number_parameters >= 3 =>
+            {
                 // For EXCEPTION_IN_PAGE_ERROR, Windows puts the address that
                 // caused the fault in exception_information[1].
                 // exception_information[0] is 0 if the violation was caused by
@@ -4338,13 +4340,11 @@ impl CrashReason {
                 // which is the explanation for why this error occured.
                 // This information is useful in addition to the code address, which
                 // will be present in the crash thread's instruction field anyway.
-                if record.number_parameters >= 3 {
-                    // NOTE: address := info[1];
-                    // The status code is 32-bits wide, ignore the upper 32 bits
-                    let nt_status = info[2] & 0xffff_ffff;
-                    if let Some(ty) = err::ExceptionCodeWindowsInPageErrorType::from_u64(info[0]) {
-                        reason = CrashReason::WindowsInPageError(ty, nt_status);
-                    }
+                // NOTE: address := info[1];
+                // The status code is 32-bits wide, ignore the upper 32 bits
+                let nt_status = info[2] & 0xffff_ffff;
+                if let Some(ty) = err::ExceptionCodeWindowsInPageErrorType::from_u64(info[0]) {
+                    reason = CrashReason::WindowsInPageError(ty, nt_status);
                 }
             }
             CrashReason::WindowsNtStatus(err::NtStatusWindows::STATUS_STACK_BUFFER_OVERRUN)


### PR DESCRIPTION
dump_syms 2.3.6+ now emits AArch64 function-entry CFI with .ra: x30, fixing mozilla/dump_syms#744. rust-minidump still dropped x30 after frame-pointer unwinding, so a following CFI unwind at a function entry could not evaluate that return-address rule and the walk would stop or fall back to scanning.

Recover the caller's saved LR from the caller frame record when ARM64 frame-pointer unwinding has a readable caller FP, and mark x30 valid. Also allow a CFI result with unchanged sp when it changes pc, matching function-entry rows whose CFA is still sp+0 while preserving the backwards/same-frame guard.

Regression coverage builds an FP -> CFI chain matching the new dump_syms output.

Fixes: https://github.com/rust-minidump/rust-minidump/issues/1138

Related: https://github.com/mozilla/dump_syms/issues/744

Related: https://github.com/mozilla/dump_syms/pull/745

Issue-tracker context: https://bugzilla.mozilla.org/show_bug.cgi?id=1526052