### PR TITLE
feat(minidump-unwind): add configurable UnwindStrategy to SymbolProvider

### DIFF
--- a/minidump-unwind/src/amd64.rs
+++ b/minidump-unwind/src/amd64.rs
@@ -423,11 +423,23 @@ where
 {
     // .await doesn't like closures, so don't use Option chaining
     let mut frame = None;
-    if frame.is_none() {
-        frame = get_caller_by_cfi(ctx, args).await;
-    }
-    if frame.is_none() {
-        frame = get_caller_by_frame_pointer(ctx, args);
+    match args.symbol_provider.unwind_strategy() {
+        UnwindStrategy::CfiFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+        }
+        UnwindStrategy::FramePointerFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+        }
     }
     if frame.is_none() {
         frame = get_caller_by_scan(ctx, args).await;

--- a/minidump-unwind/src/arm.rs
+++ b/minidump-unwind/src/arm.rs
@@ -284,11 +284,23 @@ where
 {
     // .await doesn't like closures, so don't use Option chaining
     let mut frame = None;
-    if frame.is_none() {
-        frame = get_caller_by_cfi(ctx, args).await;
-    }
-    if frame.is_none() {
-        frame = get_caller_by_frame_pointer(ctx, args);
+    match args.symbol_provider.unwind_strategy() {
+        UnwindStrategy::CfiFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+        }
+        UnwindStrategy::FramePointerFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+        }
     }
     if frame.is_none() {
         frame = get_caller_by_scan(ctx, args).await;

--- a/minidump-unwind/src/arm64.rs
+++ b/minidump-unwind/src/arm64.rs
@@ -423,11 +423,23 @@ where
 {
     // .await doesn't like closures, so don't use Option chaining
     let mut frame = None;
-    if frame.is_none() {
-        frame = get_caller_by_cfi(ctx, args).await;
-    }
-    if frame.is_none() {
-        frame = get_caller_by_frame_pointer(ctx, args);
+    match args.symbol_provider.unwind_strategy() {
+        UnwindStrategy::CfiFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+        }
+        UnwindStrategy::FramePointerFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+        }
     }
     if frame.is_none() {
         frame = get_caller_by_scan(ctx, args).await;

--- a/minidump-unwind/src/arm64_old.rs
+++ b/minidump-unwind/src/arm64_old.rs
@@ -423,11 +423,23 @@ where
 {
     // .await doesn't like closures, so don't use Option chaining
     let mut frame = None;
-    if frame.is_none() {
-        frame = get_caller_by_cfi(ctx, args).await;
-    }
-    if frame.is_none() {
-        frame = get_caller_by_frame_pointer(ctx, args);
+    match args.symbol_provider.unwind_strategy() {
+        UnwindStrategy::CfiFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+        }
+        UnwindStrategy::FramePointerFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+        }
     }
     if frame.is_none() {
         frame = get_caller_by_scan(ctx, args).await;

--- a/minidump-unwind/src/lib.rs
+++ b/minidump-unwind/src/lib.rs
@@ -45,7 +45,7 @@ impl<P> GetCallerFrameArgs<'_, P> {
 
 mod impl_prelude {
     pub(crate) use super::{
-        CfiStackWalker, FrameTrust, GetCallerFrameArgs, StackFrame, SymbolProvider,
+        CfiStackWalker, FrameTrust, GetCallerFrameArgs, StackFrame, SymbolProvider, UnwindStrategy,
     };
 }
 

--- a/minidump-unwind/src/mips.rs
+++ b/minidump-unwind/src/mips.rs
@@ -206,6 +206,8 @@ where
     super::instruction_seems_valid_by_symbols(instruction, modules, symbol_provider).await
 }
 
+// NOTE: MIPS has no frame-pointer-based unwinder, so `UnwindStrategy` has no
+// effect here; CFI is always tried first, then stack scanning.
 pub async fn get_caller_frame<P>(
     ctx: &MipsContext,
     args: &GetCallerFrameArgs<'_, P>,

--- a/minidump-unwind/src/symbols/mod.rs
+++ b/minidump-unwind/src/symbols/mod.rs
@@ -61,6 +61,25 @@ pub use breakpad_symbols::{
 #[cfg(feature = "debuginfo-unwind")]
 pub mod debuginfo;
 
+/// Controls the order in which per-frame unwind methods are attempted.
+///
+/// Stack scanning is always tried last, regardless of strategy, since it is
+/// the least reliable of the three and only ever used when neither of the
+/// other two methods produced a usable frame.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum UnwindStrategy {
+    /// Try CFI (call frame information, e.g. `.eh_frame`/`.debug_frame`) first,
+    /// falling back to the frame pointer chain if CFI is unavailable or does
+    /// not cover the current instruction. This is the historical default.
+    #[default]
+    CfiFirst,
+    /// Try the frame pointer chain first, falling back to CFI. This mirrors
+    /// what debuggers like GDB do by default, and can produce more reliable
+    /// unwinds for binaries built with frame pointers preserved
+    /// (e.g. `-fno-omit-frame-pointer`) when CFI is present but inaccurate.
+    FramePointerFirst,
+}
+
 /// The [`SymbolProvider`] is the main extension point for minidump processing.
 ///
 /// It is primarily used by the `process_minidump` function to do stack
@@ -143,6 +162,13 @@ pub trait SymbolProvider {
     fn pending_stats(&self) -> PendingSymbolStats {
         PendingSymbolStats::default()
     }
+
+    /// The [`UnwindStrategy`] to use when walking frames with this provider.
+    ///
+    /// Defaults to [`UnwindStrategy::CfiFirst`], the historical behavior.
+    fn unwind_strategy(&self) -> UnwindStrategy {
+        UnwindStrategy::CfiFirst
+    }
 }
 
 #[async_trait]
@@ -177,6 +203,10 @@ impl SymbolProvider for &(dyn SymbolProvider + Sync) {
 
     fn pending_stats(&self) -> PendingSymbolStats {
         (*self).pending_stats()
+    }
+
+    fn unwind_strategy(&self) -> UnwindStrategy {
+        (*self).unwind_strategy()
     }
 }
 

--- a/minidump-unwind/src/x86.rs
+++ b/minidump-unwind/src/x86.rs
@@ -369,11 +369,23 @@ where
 {
     // .await doesn't like closures, so don't use Option chaining
     let mut frame = None;
-    if frame.is_none() {
-        frame = get_caller_by_cfi(ctx, args).await;
-    }
-    if frame.is_none() {
-        frame = get_caller_by_frame_pointer(ctx, args);
+    match args.symbol_provider.unwind_strategy() {
+        UnwindStrategy::CfiFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+        }
+        UnwindStrategy::FramePointerFirst => {
+            if frame.is_none() {
+                frame = get_caller_by_frame_pointer(ctx, args);
+            }
+            if frame.is_none() {
+                frame = get_caller_by_cfi(ctx, args).await;
+            }
+        }
     }
     if frame.is_none() {
         frame = get_caller_by_scan(ctx, args).await;


### PR DESCRIPTION
## Problem

`get_caller_frame()` has always tried CFI (call frame information, e.g.
`.eh_frame`/`.debug_frame`) before the frame-pointer chain, hardcoded per
architecture. Debuggers like GDB do the opposite by default: walk the frame
pointer chain first, falling back to CFI. For binaries built with frame
pointers preserved (`-fno-omit-frame-pointer`) whose CFI happens to be
present but inaccurate — e.g. FPO'd system libraries with truncated or
wrong CFI — CFI-first can walk into garbage before falling back, where
frame-pointer-first would have produced a correct unwind immediately.
There was no way for a caller to opt into that ordering.

## Solution

- Adds `UnwindStrategy` (`CfiFirst` — the default, matching prior hardcoded
  behavior — or `FramePointerFirst`) to `minidump-unwind::symbols`.
- Adds `SymbolProvider::unwind_strategy()`, a default method returning
  `UnwindStrategy::CfiFirst`, so existing implementors are unaffected
  unless they explicitly override it.
- The per-architecture `get_caller_frame()` implementations (`amd64`,
  `x86`, `arm`, `arm64`, `arm64_old`) now consult
  `args.symbol_provider.unwind_strategy()` to decide which of CFI or the
  frame pointer chain to attempt first. Stack scanning remains the
  unconditional last resort in both orders — this only reorders the first
  two methods, never removes the fallback chain.
- `mips` has no frame-pointer unwinder, so it's left untouched (CFI, then
  scan) — there's nothing to reorder there.

This is purely additive: no existing behavior changes for any caller that
doesn't override the new default method.

## Motivating use case

Built for [getsentry/symbolicator](https://github.com/getsentry/symbolicator),
which is adding a `frame_pointer_first` config option (see companion PR
[getsentry/symbolicator#TODO]) to better match GDB's default unwinding
behavior when symbolicating minidumps. In one real case, a Windows
minidump's `rpcrt4.dll` frame has FPO'd (i.e. absent/misleading) CFI;
`cfi_first` degrades to `trust: scan` there while `frame_pointer_first`
resolves it via `trust: fp`.

## Testing

- Full `minidump-unwind` test suite (76 tests, all passing).
- New integration coverage in the downstream Symbolicator PR:
  a same-input comparison test asserting both strategies agree when CFI is
  trustworthy, and a regression test against a real Windows minidump
  showing the FPO divergence described above.