### PR TITLE
Update most crate dependencies to latest versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -164,13 +164,13 @@ checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "breakpad-symbols"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "cab",
@@ -247,9 +247,9 @@ checksum = "68ccbd3153aa153b2f5eff557537ffce81e4dd6c50ae0eddc41dc8d0c388436f"
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -305,7 +305,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -467,7 +467,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -600,9 +600,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -632,14 +632,14 @@ dependencies = [
 
 [[package]]
 name = "framehop"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a7d65f75e837647bf8b1594ad3b559a929ee9a58d956d9f46999749957b6b9"
+checksum = "6f54fe4785e899d4d6f43793b151c63c5647240fc630b005509d2614a939f693"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "fallible-iterator",
- "gimli 0.32.3",
+ "gimli 0.33.0",
  "macho-unwind-info",
  "pe-unwind-info",
 ]
@@ -683,7 +683,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -754,11 +754,10 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
  "stable_deref_trait",
 ]
 
@@ -1018,16 +1017,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1058,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1229,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "arbitrary",
  "ctor",
@@ -1244,7 +1233,7 @@ dependencies = [
  "procfs-core",
  "prost 0.14.1",
  "range-map",
- "scroll",
+ "scroll 0.13.0",
  "test-assembler",
  "thiserror",
  "time",
@@ -1254,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-common"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "arbitrary",
  "bitflags",
@@ -1262,13 +1251,13 @@ dependencies = [
  "num-derive",
  "num-traits",
  "range-map",
- "scroll",
+ "scroll 0.13.0",
  "smart-default",
 ]
 
 [[package]]
 name = "minidump-processor"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
@@ -1279,7 +1268,7 @@ dependencies = [
  "minidump-common",
  "minidump-synth",
  "minidump-unwind",
- "scroll",
+ "scroll 0.13.0",
  "serde",
  "serde_json",
  "test-assembler",
@@ -1291,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "minidump-stackwalk"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "clap",
  "indicatif",
@@ -1310,16 +1299,16 @@ dependencies = [
 
 [[package]]
 name = "minidump-synth"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "minidump-common",
- "scroll",
+ "scroll 0.13.0",
  "test-assembler",
 ]
 
 [[package]]
 name = "minidump-unwind"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
@@ -1330,8 +1319,8 @@ dependencies = [
  "memmap2",
  "minidump",
  "minidump-common",
- "object",
- "scroll",
+ "object 0.39.1",
+ "scroll 0.13.0",
  "test-assembler",
  "tokio",
  "tracing",
@@ -1414,13 +1403,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1447,6 +1436,15 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1511,7 +1509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b8733697ccc3aa405a9b2cf485a42746ad1cf73d3b0497b79b24f9e874a71"
 dependencies = [
  "fallible-iterator",
- "scroll",
+ "scroll 0.12.0",
  "uuid",
 ]
 
@@ -1596,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "procfs-core"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags",
  "hex",
@@ -1633,7 +1631,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1646,7 +1644,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1812,7 +1810,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2001,7 +1999,7 @@ dependencies = [
  "memchr",
  "msvc-demangler",
  "nom",
- "object",
+ "object 0.36.7",
  "pdb-addr2line",
  "rangemap",
  "rustc-demangle",
@@ -2032,19 +2030,25 @@ name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+
+[[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2074,7 +2078,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2113,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2179,7 +2183,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2256,6 +2260,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,7 +2287,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2324,7 +2339,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2417,7 +2432,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2460,20 +2475,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2508,7 +2523,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2689,7 +2704,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
@@ -3087,7 +3102,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -3108,7 +3123,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3128,7 +3143,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -3168,7 +3183,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 license = "MIT"
 homepage = "https://github.com/rust-minidump/rust-minidump"
 repository = "https://github.com/rust-minidump/rust-minidump"
-version = "0.26.1"
+version = "0.27.0"
 
 [workspace.metadata.release]
 shared-version = true

--- a/breakpad-symbols/Cargo.toml
+++ b/breakpad-symbols/Cargo.toml
@@ -28,7 +28,7 @@ circular = "0.3.0"
 debugid = "0.8.0"
 futures-util = "0.3"
 tracing = { version = "0.1.34", features = ["log"] }
-minidump-common = { version = "0.26.1", path = "../minidump-common" }
+minidump-common = { version = "0.27", path = "../minidump-common" }
 nom = "7"
 range-map = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [

--- a/minidump-common/Cargo.toml
+++ b/minidump-common/Cargo.toml
@@ -16,8 +16,8 @@ travis-ci = { repository = "rust-minidump/rust-minidump" }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 bitflags = "2"
 debugid = "0.8.0"
-num-derive = "0.4"
+num-derive = "0.5"
 num-traits = "0.2"
 range-map = "0.2"
-scroll = { version = "0.12.0", features = ["derive"] }
+scroll = { version = "0.13.0", features = ["derive"] }
 smart-default = "0.7.0"

--- a/minidump-processor/Cargo.toml
+++ b/minidump-processor/Cargo.toml
@@ -25,13 +25,13 @@ mozilla_cab_symbols = ["breakpad-symbols/mozilla_cab_symbols"]
 
 [dependencies]
 async-trait = "0.1.52"
-breakpad-symbols = { version = "0.26.1", path = "../breakpad-symbols" }
+breakpad-symbols = { version = "0.27", path = "../breakpad-symbols" }
 debugid = "0.8.0"
 futures-util = "0.3.25"
-minidump = { version = "0.26.1", path = "../minidump" }
-minidump-common = { version = "0.26.1", path = "../minidump-common" }
-minidump-unwind = { version = "0.26.1", path = "../minidump-unwind" }
-scroll = "0.12.0"
+minidump = { version = "0.27", path = "../minidump" }
+minidump-common = { version = "0.27", path = "../minidump-common" }
+minidump-unwind = { version = "0.27", path = "../minidump-unwind" }
+scroll = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"

--- a/minidump-stackwalk/Cargo.toml
+++ b/minidump-stackwalk/Cargo.toml
@@ -21,10 +21,10 @@ mozilla_cab_symbols = ["minidump-processor/mozilla_cab_symbols"]
 [dependencies]
 clap = { version = "4.5.0", features = ["cargo", "wrap_help", "derive"] }
 indicatif = "0.17.0"
-minidump = { version = "0.26.1", path = "../minidump" }
-minidump-common = { version = "0.26.1", path = "../minidump-common" }
-minidump-processor = { version = "0.26.1", path = "../minidump-processor" }
-minidump-unwind = { version = "0.26.1", path = "../minidump-unwind", features = ["debuginfo", "http"] }
+minidump = { version = "0.27", path = "../minidump" }
+minidump-common = { version = "0.27", path = "../minidump-common" }
+minidump-processor = { version = "0.27", path = "../minidump-processor" }
+minidump-unwind = { version = "0.27", path = "../minidump-unwind", features = ["debuginfo", "http"] }
 tokio = { version = "1.12.0", features = ["full"] }
 tracing = { version = "0.1.34", features = ["log"] }
 tracing-subscriber = "0.3.14"

--- a/minidump-synth/Cargo.toml
+++ b/minidump-synth/Cargo.toml
@@ -10,5 +10,5 @@ repository.workspace = true
 
 [dependencies]
 test-assembler = "0.1.5"
-minidump-common = { version = "0.26.1", path = "../minidump-common" }
-scroll = "0.12.0"
+minidump-common = { version = "0.27", path = "../minidump-common" }
+scroll = "0.13.0"

--- a/minidump-unwind/Cargo.toml
+++ b/minidump-unwind/Cargo.toml
@@ -24,15 +24,15 @@ http = ["breakpad-symbols/http"]
 
 [dependencies]
 async-trait = "0.1.52"
-breakpad-symbols = { version = "0.26.1", path = "../breakpad-symbols" }
+breakpad-symbols = { version = "0.27", path = "../breakpad-symbols" }
 cachemap2 = { version = "0.3.0", optional = true }
-framehop = { version = "0.15", optional = true }
+framehop = { version = "0.16", optional = true }
 futures-util = { version = "0.3.25", optional = true }
 memmap2 = { version = "0.9", optional = true }
-minidump = { version = "0.26.1", path = "../minidump" }
-minidump-common = { version = "0.26.1", path = "../minidump-common" }
-object = { version = "0.36", default-features = false, features = ["read"], optional = true }
-scroll = "0.12.0"
+minidump = { version = "0.27", path = "../minidump" }
+minidump-common = { version = "0.27", path = "../minidump-common" }
+object = { version = "0.39", default-features = false, features = ["read"], optional = true }
+scroll = "0.13.0"
 tracing = { version = "0.1.34", features = ["log"] }
 wholesym = { version = "0.8", optional = true }
 

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -17,11 +17,11 @@ debugid = "0.8.0"
 encoding_rs = "0.8"
 tracing = { version = "0.1.34", features = ["log"] }
 memmap2 = "0.9"
-minidump-common = { version = "0.26.1", path = "../minidump-common" }
+minidump-common = { version = "0.27", path = "../minidump-common" }
 num-traits = "0.2"
-procfs-core = { version = "0.17", default-features = false }
+procfs-core = { version = "0.18", default-features = false }
 range-map = "0.2"
-scroll = "0.12.0"
+scroll = "0.13.0"
 thiserror = "2"
 time = { version = "0.3.34", features = ["formatting"] }
 uuid = "1.0.0"


### PR DESCRIPTION
Omitted:
- reqwest 0.13: there are no code changes needed, but it adds a lot of dependencies
- nom 8: code changes needed